### PR TITLE
Implicit Runge-Kutta Convolution Quadrature

### DIFF
--- a/examples/tdefie_irk.jl
+++ b/examples/tdefie_irk.jl
@@ -1,89 +1,9 @@
 include("../src/BEAST.jl")
 using CompScienceMeshes, BEAST, StaticArrays
 
-sol = 5.0;
-
-struct RungeKuttaConvolutionQuadrature{T,N,NN}
-	laplaceKernel         # function of s that returns an IntegralOperator
-	A                     :: SArray{Tuple{N,N},T,2,NN}
-	b                     :: SVector{N,T}
-	Δt                    :: T
-	zTransformedTermCount :: Int
-	contourRadius         :: T
-end
-scalartype{T,N,NN}(rkcq::RungeKuttaConvolutionQuadrature{T,N,NN}) = Complex{T};
-
-LaplaceEFIO{T}(s::T) = MWSingleLayer3D(-s/sol, s*s/sol, T(sol));
-
-# M = H*diagm(D)*invH
-struct DiagonalizedMatrix{T,N,NN}
-	H    :: SArray{Tuple{N,N},Complex{T},2,NN}
-	invH :: SArray{Tuple{N,N},Complex{T},2,NN}
-	D    :: SVector{N,Complex{T}}
-end
-
-# M = H*diagm(D)*invH
-function DiagonalizedMatrix{T,N,NN}(M :: SArray{Tuple{N,N},Complex{T},2,NN})
-	ef = eigfact(Array{Complex{T},2}(M));
-
-	efValues = SVector{N,Complex{T}}(ef.values);
-	efVectors = SArray{Tuple{N,N},Complex{T},2,NN}(ef.vectors);
-	return DiagonalizedMatrix(efVectors, inv(efVectors), efValues);
-end
-
-	#########################################
-	#                  LHS                  #
-	#########################################
-
-function BEAST.assemble(rkcq::RungeKuttaConvolutionQuadrature, testfns::BEAST.StagedTimeStep, trialfns::BEAST.StagedTimeStep)
-
-	laplaceKernel = rkcq.laplaceKernel;
-	A = rkcq.A;
-	b = rkcq.b;
-	Δt = rkcq.Δt;
-	Q = rkcq.zTransformedTermCount;
-	rho = rkcq.contourRadius;
-	p = length(b);
-
-    test_spatial_basis  = testfns.spatialBasis
-    trial_spatial_basis = trialfns.spatialBasis
-	Tz = promote_type(scalartype(rkcq), BEAST.scalartype(testfns), BEAST.scalartype(trialfns))
-
-	# Compute the Z transformed sequence
-    M = numfunctions(test_spatial_basis)
-    N = numfunctions(trial_spatial_basis)
-	Zz = Vector{Array{Tz,2}}(Q);
-	for q = 0:Q-1
-		# Build a temporary matrix for each eigenvalue
-		s = BEAST.laplace_to_z(rho, q, Q, Δt, A, b);
-		sFactorized = DiagonalizedMatrix(s);
-		blocksEigenvalues = [BEAST.assemble(laplaceKernel(sD), test_spatial_basis, trial_spatial_basis) for sD in sFactorized.D];
-		Zz[q+1] = zeros(Tz, M*p, N*p)
-
-		# Compute the Z transformed matrix by block
-		for m = 1:M
-			for n = 1:N
-				D = SVector{p,Tz}([blocksEigenvalues[i][m,n] for i in 1:p])
-				Zz[q+1][(m-1)*p+(1:p),(n-1)*p+(1:p)] = sFactorized.H * diagm(D) * sFactorized.invH;
-			end
-		end
-	end
-
-	# return the inverse Z tranformed
-	kmax = Q;
-	T = real(Tz);
-	Z = zeros(T, M*p, N*p, kmax)
-	for q = 0:kmax-1
-		Z[:,:,q+1] = real(BEAST.inverse_z_transform(q, rho, Q, Zz));
-	end
-    return Z
-
-end
-
-#####################################################################
-
 o, x, y, z = euclidianbasis(3)
 
+sol = 5.0;
 #Δt, Nt = 0.08/sol,400
 Δt, Nt = 100.0/sol,200
 
@@ -99,6 +19,8 @@ gaussian = creategaussian(duration, delay, duration)
 
 direction, polarisation = z, x
 E = planewave(polarisation, direction, derive(gaussian), sol)
+
+LaplaceEFIO{T}(s::T) = MWSingleLayer3D(-s/sol, s*s/sol, T(sol));
 T = RungeKuttaConvolutionQuadrature(LaplaceEFIO, A, b, Δt, 15, 1.0001);
 
 @hilbertspace j

--- a/examples/tdefie_irk.jl
+++ b/examples/tdefie_irk.jl
@@ -1,10 +1,8 @@
-include("../src/BEAST.jl")
-using CompScienceMeshes, BEAST, StaticArrays
+using CompScienceMeshes, BEAST
 
 o, x, y, z = euclidianbasis(3)
 
 sol = 5.0;
-#Δt, Nt = 0.08/sol,400
 Δt, Nt = 100.0/sol,200
 
 D, Δx = 1.0, 0.45
@@ -21,12 +19,11 @@ direction, polarisation = z, x
 E = planewave(polarisation, direction, derive(gaussian), sol)
 
 LaplaceEFIO{T}(s::T) = MWSingleLayer3D(-s/sol, s*s/sol, T(sol));
-T = RungeKuttaConvolutionQuadrature(LaplaceEFIO, A, b, Δt, 15, 1.0001);
+kmax = 15;
+rho = 1.0001;
+T = RungeKuttaConvolutionQuadrature(LaplaceEFIO, A, b, Δt, kmax, rho);
 
 @hilbertspace j
 @hilbertspace j′
 tdefie = @discretise T[j′,j] == -1E[j′]   j∈V  j′∈V
 xefie_irk = solve(tdefie)
-
-using PyPlot
-semilogy(abs.(xefie_irk[2,:]))

--- a/examples/tdefie_irk.jl
+++ b/examples/tdefie_irk.jl
@@ -1,3 +1,4 @@
+include("../src/BEAST.jl")
 using CompScienceMeshes, BEAST, StaticArrays
 
 sol = 5.0;
@@ -22,23 +23,6 @@ end
 scalartype{T,N,NN}(rkcq::RungeKuttaConvolutionQuadrature{T,N,NN}) = Complex{T};
 
 LaplaceEFIO{T}(s::T) = MWSingleLayer3D(-s/sol, s*s/sol, T(sol));
-
-function ButcherTableauRadau2Stages()
-	A = @SMatrix [5/12   -1/12
-	              3/4    1/4];
-	b = @SVector [3/4, 1/4];
-	c = @SVector [1/3, 1.0];
-	return (A, b, c);
-end
-
-function ButcherTableauRadau3Stages()
-	A = @SMatrix [(88.0-7.0*sqrt(6.0))/360.0       (296.0-169.0*sqrt(6.0))/1800.0   (-2.0+3.0*sqrt(6.0))/225.0
-	              (296.0+169.0*sqrt(6.0))/1800.0   (88.0+7.0*sqrt(6.0))/360.0       (-2.0-3.0*sqrt(6.0))/225.0
-	              (16.0-sqrt(6.0))/36.0            (16.0+sqrt(6.0))/36.0             1/9];
-	b = @SVector [(16.0-sqrt(6.0))/36.0,    (16.0+sqrt(6.0))/36.0,    1/9];
-	c = @SVector [(4.0-sqrt(6.0))/10.0,     (4.0+sqrt(6.0))/10.0,     1.0];
-	return (A, b, c);
-end
 
 # M = H*diagm(D)*invH
 struct DiagonalizedMatrix{T,N,NN}
@@ -206,7 +190,7 @@ D, Δx = 1.0, 0.45
 Γ = meshsphere(D, Δx)
 X = raviartthomas(Γ)
 
-(A, b, c) = ButcherTableauRadau3Stages();
+(A, b, c) = butcher_tableau_radau_2stages();
 V = StagedTimeStep(X, c, Δt, Nt);
 
 duration, delay, amplitude = 2000.0/sol, 2000.0/sol, 1.0

--- a/examples/tdefie_irk.jl
+++ b/examples/tdefie_irk.jl
@@ -1,0 +1,225 @@
+using CompScienceMeshes, BEAST, StaticArrays
+
+sol = 5.0;
+
+struct StagedTimeStep{T,N}
+	spatialBasis
+	c  :: SVector{N,T}
+	Δt :: T
+	Nt :: Int
+end
+scalartype{T,N}(sts::StagedTimeStep{T,N}) = T;
+BEAST.temporalbasis{T,N}(sts :: StagedTimeStep{T,N}) = BEAST.timebasisdelta(sts.Δt, sts.Nt)
+
+struct RungeKuttaConvolutionQuadrature{T,N,NN}
+	laplaceKernel         # function of s that returns an IntegralOperator
+	A                     :: SArray{Tuple{N,N},T,2,NN}
+	b                     :: SVector{N,T}
+	Δt                    :: T
+	zTransformedTermCount :: Int
+	contourRadius         :: T
+end
+scalartype{T,N,NN}(rkcq::RungeKuttaConvolutionQuadrature{T,N,NN}) = Complex{T};
+
+LaplaceEFIO{T}(s::T) = MWSingleLayer3D(-s/sol, s*s/sol, T(sol));
+
+function ButcherTableauRadau2Stages()
+	A = @SMatrix [5/12   -1/12
+	              3/4    1/4];
+	b = @SVector [3/4, 1/4];
+	c = @SVector [1/3, 1.0];
+	return (A, b, c);
+end
+
+function ButcherTableauRadau3Stages()
+	A = @SMatrix [(88.0-7.0*sqrt(6.0))/360.0       (296.0-169.0*sqrt(6.0))/1800.0   (-2.0+3.0*sqrt(6.0))/225.0
+	              (296.0+169.0*sqrt(6.0))/1800.0   (88.0+7.0*sqrt(6.0))/360.0       (-2.0-3.0*sqrt(6.0))/225.0
+	              (16.0-sqrt(6.0))/36.0            (16.0+sqrt(6.0))/36.0             1/9];
+	b = @SVector [(16.0-sqrt(6.0))/36.0,    (16.0+sqrt(6.0))/36.0,    1/9];
+	c = @SVector [(4.0-sqrt(6.0))/10.0,     (4.0+sqrt(6.0))/10.0,     1.0];
+	return (A, b, c);
+end
+
+# M = H*diagm(D)*invH
+struct DiagonalizedMatrix{T,N,NN}
+	H    :: SArray{Tuple{N,N},Complex{T},2,NN}
+	invH :: SArray{Tuple{N,N},Complex{T},2,NN}
+	D    :: SVector{N,Complex{T}}
+end
+
+# M = H*diagm(D)*invH
+function DiagonalizedMatrix{T,N,NN}(M :: SArray{Tuple{N,N},Complex{T},2,NN})
+	ef = eigfact(Array{Complex{T},2}(M));
+
+	efValues = SVector{N,Complex{T}}(ef.values);
+	efVectors = SArray{Tuple{N,N},Complex{T},2,NN}(ef.vectors);
+	return DiagonalizedMatrix(efVectors, inv(efVectors), efValues);
+end
+
+function LaplaceToZ(rho, k, N, dt, A, b)
+	z = rho * exp(2*im*pi*k/N);
+	s = inv(dt * (A + ones(b) * b' / (z-1)));
+	return s;
+end
+
+function InverseZTransform{T}(k, rho, N, X::AbstractArray{T,1})
+	result = zero(X[1]);
+	for n = 0:(N-1)
+		result += X[n+1] * exp(2*im*pi*k*n/N)
+	end
+	result *= (rho^k)/N;
+	return result;
+end
+
+	#########################################
+	#                  RHS                  #
+	#########################################
+
+struct TimeBasisDeltaShifted{T} <: BEAST.AbstractTimeBasisFunction
+	tbf   :: BEAST.TimeBasisDelta{T}
+	shift :: T
+end
+BEAST.scalartype(x::TimeBasisDeltaShifted) = BEAST.scalartype(x.tbf)
+BEAST.numfunctions(x::TimeBasisDeltaShifted) = BEAST.numfunctions(x.tbf)
+BEAST.refspace(x::TimeBasisDeltaShifted) = BEAST.refspace(x.tbf)
+BEAST.timestep(x::TimeBasisDeltaShifted) = BEAST.timestep(x.tbf)
+BEAST.numintervals(x::TimeBasisDeltaShifted) = BEAST.numintervals(x.tbf)
+
+function BEAST.assemblydata(tbds::TimeBasisDeltaShifted)
+	tbf = tbds.tbf
+
+    T = BEAST.scalartype(tbf)
+    Δt = BEAST.timestep(tbf)
+
+    z = zero(BEAST.scalartype(tbf))
+    w = one(BEAST.scalartype(tbf))
+
+    num_cells = BEAST.numfunctions(tbf)
+    num_refs  = 1
+
+    max_num_funcs = 1
+    num_funcs = zeros(Int, num_cells, num_refs)
+    data = fill((0,z), max_num_funcs, num_refs, num_cells)
+
+    els = [ simplex(point((i-0+tbds.shift)*Δt),point((i+1+tbds.shift)*Δt)) for i in 1:num_cells ]
+
+    for k in 1 : BEAST.numfunctions(tbf)
+        data[1,1,k] = (k,w)
+    end
+
+    return els, BEAST.AssemblyData(data)
+end
+
+function BEAST.assemble(exc::BEAST.TDFunctional, testST::StagedTimeStep)
+	stageCount = length(testST.c);
+    spatialBasis = testST.spatialBasis;
+    Nt = testST.Nt;
+	Δt = testST.Δt;
+    Z = zeros(eltype(exc), BEAST.numfunctions(spatialBasis) * stageCount, Nt)
+	for i = 1:stageCount
+		store(v,m,k) = (Z[(m-1)*stageCount+i,k] += v);
+		tbsd = TimeBasisDeltaShifted(BEAST.timebasisdelta(Δt, Nt), testST.c[i]);
+		BEAST.assemble!(exc, spatialBasis ⊗ tbsd, store);
+	end
+    return Z
+end
+
+	#########################################
+	#                  LHS                  #
+	#########################################
+
+function BEAST.assemble(rkcq::RungeKuttaConvolutionQuadrature, testfns::StagedTimeStep, trialfns::StagedTimeStep)
+
+	laplaceKernel = rkcq.laplaceKernel;
+	A = rkcq.A;
+	b = rkcq.b;
+	Δt = rkcq.Δt;
+	Q = rkcq.zTransformedTermCount;
+	rho = rkcq.contourRadius;
+	p = length(b);
+
+    test_spatial_basis  = testfns.spatialBasis
+    trial_spatial_basis = trialfns.spatialBasis
+	Tz = promote_type(scalartype(rkcq), scalartype(testfns), scalartype(trialfns))
+
+	# Compute the Z transformed sequence
+    M = numfunctions(test_spatial_basis)
+    N = numfunctions(trial_spatial_basis)
+	Zz = Vector{Array{Tz,2}}(Q);
+	for q = 0:Q-1
+		# Build a temporary matrix for each eigenvalue
+		s = LaplaceToZ(rho, q, Q, Δt, A, b);
+		sFactorized = DiagonalizedMatrix(s);
+		blocksEigenvalues = [BEAST.assemble(laplaceKernel(sD), test_spatial_basis, trial_spatial_basis) for sD in sFactorized.D];
+		Zz[q+1] = zeros(Tz, M*p, N*p)
+
+		# Compute the Z transformed matrix by block
+		for m = 1:M
+			for n = 1:N
+				D = SVector{p,Tz}([blocksEigenvalues[i][m,n] for i in 1:p])
+				Zz[q+1][(m-1)*p+(1:p),(n-1)*p+(1:p)] = sFactorized.H * diagm(D) * sFactorized.invH;
+			end
+		end
+	end
+
+	# return the inverse Z tranformed
+	kmax = Q;
+	T = real(Tz);
+	Z = zeros(T, M*p, N*p, kmax)
+	for q = 0:kmax-1
+		Z[:,:,q+1] = real(InverseZTransform(q, rho, Q, Zz));
+	end
+    return Z
+
+end
+
+function BEAST.solve(eq)
+
+    time_domain = isa(first(eq.trial_space_dict).second, BEAST.SpaceTimeBasis)
+    time_domain |= isa(first(eq.trial_space_dict).second, StagedTimeStep)
+    if time_domain
+        return BEAST.td_solve(eq)
+    end
+
+    test_space_dict  = eq.test_space_dict
+    trial_space_dict = eq.trial_space_dict
+
+    lhs = eq.equation.lhs
+    rhs = eq.equation.rhs
+
+    b = BEAST.assemble(rhs, test_space_dict)
+    Z = BEAST.assemble(lhs, test_space_dict, trial_space_dict)
+
+    u = Z \ b
+
+    return u
+end
+
+#####################################################################
+
+o, x, y, z = euclidianbasis(3)
+
+#Δt, Nt = 0.08/sol,400
+Δt, Nt = 100.0/sol,200
+
+D, Δx = 1.0, 0.45
+Γ = meshsphere(D, Δx)
+X = raviartthomas(Γ)
+
+(A, b, c) = ButcherTableauRadau3Stages();
+V = StagedTimeStep(X, c, Δt, Nt);
+
+duration, delay, amplitude = 2000.0/sol, 2000.0/sol, 1.0
+gaussian = creategaussian(duration, delay, duration)
+
+direction, polarisation = z, x
+E = planewave(polarisation, direction, derive(gaussian), sol)
+T = RungeKuttaConvolutionQuadrature(LaplaceEFIO, A, b, Δt, 15, 1.0001);
+
+@hilbertspace j
+@hilbertspace j′
+tdefie = @discretise T[j′,j] == -1E[j′]   j∈V  j′∈V
+xefie_irk = solve(tdefie)
+
+using PyPlot
+semilogy(abs.(xefie_irk[2,:]))

--- a/src/BEAST.jl
+++ b/src/BEAST.jl
@@ -71,6 +71,7 @@ include("helmholtz3d/timedomain/tdhh3dexc.jl")
 include("maxwell/timedomain/mwtdops.jl")
 include("maxwell/timedomain/mwtdexc.jl")
 
+include("utils/butchertableau.jl")
 include("utils/variational.jl")
 
 include("solvers/solver.jl")

--- a/src/BEAST.jl
+++ b/src/BEAST.jl
@@ -32,6 +32,7 @@ include("bases/rtspace.jl")
 include("bases/bcspace.jl")
 include("bases/ndspace.jl")
 
+include("bases/stagedtimestep.jl")
 include("bases/timebasis.jl")
 include("bases/tensorbasis.jl")
 

--- a/src/BEAST.jl
+++ b/src/BEAST.jl
@@ -47,6 +47,7 @@ include("timedomain/tdintegralop.jl")
 include("timedomain/tdexcitation.jl")
 include("timedomain/motlu.jl")
 include("timedomain/tdtimeops.jl")
+include("timedomain/zdomain.jl")
 
 # Support for Maxwell equations
 include("maxwell/wiltonints.jl")

--- a/src/BEAST.jl
+++ b/src/BEAST.jl
@@ -48,6 +48,7 @@ include("timedomain/tdintegralop.jl")
 include("timedomain/tdexcitation.jl")
 include("timedomain/motlu.jl")
 include("timedomain/tdtimeops.jl")
+include("timedomain/rkcq.jl")
 include("timedomain/zdomain.jl")
 
 # Support for Maxwell equations

--- a/src/bases/stagedtimestep.jl
+++ b/src/bases/stagedtimestep.jl
@@ -1,6 +1,4 @@
 
-include("timebasis.jl")
-
 export StagedTimeStep
 
 """

--- a/src/bases/stagedtimestep.jl
+++ b/src/bases/stagedtimestep.jl
@@ -9,12 +9,12 @@ N: the number of stages.
 It corresponds to a time-space basis function where each time step has
 intermediary stages given by the vertor c in a Butcher tableau (A,b,c)
 """
-struct StagedTimeStep{T,N}
-	spatialBasis
+struct StagedTimeStep{SB, T, N}
+	spatialBasis :: SB
 	c  :: SVector{N,T}
 	Δt :: T
 	Nt :: Int
 end
 
-scalartype{T,N}(sts :: StagedTimeStep{T,N}) = T;
-temporalbasis{T,N}(sts :: StagedTimeStep{T,N}) = timebasisdelta(sts.Δt, sts.Nt)
+scalartype{SB, T, N}(sts :: StagedTimeStep{SB, T, N}) = T;
+temporalbasis{SB, T, N}(sts :: StagedTimeStep{SB, T, N}) = timebasisdelta(sts.Δt, sts.Nt)

--- a/src/bases/stagedtimestep.jl
+++ b/src/bases/stagedtimestep.jl
@@ -1,0 +1,22 @@
+
+include("timebasis.jl")
+
+export StagedTimeStep
+
+"""
+    StagedTimeStep{T,N}
+
+T: the value type of the basis function.
+N: the number of stages.
+It corresponds to a time-space basis function where each time step has
+intermediary stages given by the vertor c in a Butcher tableau (A,b,c)
+"""
+struct StagedTimeStep{T,N}
+	spatialBasis
+	c  :: SVector{N,T}
+	Δt :: T
+	Nt :: Int
+end
+
+scalartype{T,N}(sts :: StagedTimeStep{T,N}) = T;
+temporalbasis{T,N}(sts :: StagedTimeStep{T,N}) = timebasisdelta(sts.Δt, sts.Nt)

--- a/src/solvers/lusolver.jl
+++ b/src/solvers/lusolver.jl
@@ -5,6 +5,7 @@ and calling a traditional lu decomposition.
 function solve(eq)
 
     time_domain = isa(first(eq.trial_space_dict).second, BEAST.SpaceTimeBasis)
+    time_domain |= isa(first(eq.trial_space_dict).second, BEAST.StagedTimeStep)
     if time_domain
         return td_solve(eq)
     end

--- a/src/solvers/lusolver.jl
+++ b/src/solvers/lusolver.jl
@@ -27,7 +27,7 @@ end
 
 function td_solve(eq)
 
-    warn("very limited sypport for automated solution of TD equations....")
+    warn("very limited support for automated solution of TD equations....")
     op = eq.equation.lhs.terms[1].kernel
     fn = eq.equation.rhs.terms[1].functional
 

--- a/src/timedomain/rkcq.jl
+++ b/src/timedomain/rkcq.jl
@@ -16,15 +16,15 @@ A, b: Coefficient matrix and vectors from the Butcher tableau.
 zTransformedTermCount: Number of terms in the inverse Z-transform.
 contourRadius: radius of circle used as integration contour for the inverse Z-transform.
 """
-struct RungeKuttaConvolutionQuadrature{T,N,NN}
-	laplaceKernel         # function of s that returns an IntegralOperator
+struct RungeKuttaConvolutionQuadrature{LK, T, N, NN}
+	laplaceKernel         :: LK # function of s that returns an IntegralOperator
 	A                     :: SArray{Tuple{N,N},T,2,NN}
 	b                     :: SVector{N,T}
 	Δt                    :: T
 	zTransformedTermCount :: Int
 	contourRadius         :: T
 end
-scalartype{T,N,NN}(rkcq::RungeKuttaConvolutionQuadrature{T,N,NN}) = Complex{T};
+scalartype{LK, T, N, NN}(rkcq::RungeKuttaConvolutionQuadrature{LK, T, N, NN}) = Complex{T};
 
 # M = H*diagm(D)*invH
 struct DiagonalizedMatrix{T,N,NN}
@@ -37,8 +37,8 @@ end
 function diagonalizedmatrix{T,N,NN}(M :: SArray{Tuple{N,N},Complex{T},2,NN})
 	ef = eigfact(Array{Complex{T},2}(M));
 
-	efValues = SVector{N,Complex{T}}(ef.values);
-	efVectors = SArray{Tuple{N,N},Complex{T},2,NN}(ef.vectors);
+	efValues = SVector{N,Complex{T}}(ef.values)  :: SVector{N,Complex{T}};
+	efVectors = SArray{Tuple{N,N},Complex{T},2,NN}(ef.vectors) :: SArray{Tuple{N,N},Complex{T},2,NN};
 	return DiagonalizedMatrix(efVectors, inv(efVectors), efValues);
 end
 
@@ -66,17 +66,24 @@ function assemble(rkcq :: RungeKuttaConvolutionQuadrature,
 	N = numfunctions(trial_spatial_basis);
 	Tz = promote_type(scalartype(rkcq), scalartype(testfns), scalartype(trialfns));
 	Zz = Vector{Array{Tz,2}}(Qmax);
+	blocksEigenvalues = Vector{Array{Tz,2}}(p);
+	tmpDiag = Vector{Tz}(p);
 	for q = 0:Qmax-1
 		# Build a temporary matrix for each eigenvalue
 		s = laplace_to_z(rho, q, Q, Δt, A, b);
 		sFactorized = diagonalizedmatrix(s);
-		blocksEigenvalues = [assemble(laplaceKernel(sD), test_spatial_basis, trial_spatial_basis) for sD in sFactorized.D];
-		Zz[q+1] = zeros(Tz, M*p, N*p)
+		for (i,sD) in enumerate(sFactorized.D)
+			blocksEigenvalues[i] = assemble(laplaceKernel(sD), test_spatial_basis, trial_spatial_basis);
+		end
 
 		# Compute the Z transformed matrix by block
+		Zz[q+1] = zeros(Tz, M*p, N*p);
 		for m = 1:M
 			for n = 1:N
-				D = SVector{p,Tz}([blocksEigenvalues[i][m,n] for i in 1:p])
+				for i = 1:p
+					tmpDiag[i] = blocksEigenvalues[i][m,n];
+				end
+				D = SVector{p,Tz}(tmpDiag);
 				Zz[q+1][(m-1)*p+(1:p),(n-1)*p+(1:p)] = sFactorized.H * diagm(D) * sFactorized.invH;
 			end
 		end

--- a/src/timedomain/rkcq.jl
+++ b/src/timedomain/rkcq.jl
@@ -57,12 +57,16 @@ function assemble(rkcq :: RungeKuttaConvolutionQuadrature,
 	test_spatial_basis  = testfns.spatialBasis;
 	trial_spatial_basis = trialfns.spatialBasis;
 
-	# Compute the Z transformed sequence
+	# Compute the Z transformed sequence.
+	# Assume that the operator applied on the conjugate of s is the same as the
+	# conjugate of the operator applied on s,
+	# so that only half of the values are computed
+	Qmax = Q>>1+1;
 	M = numfunctions(test_spatial_basis);
 	N = numfunctions(trial_spatial_basis);
 	Tz = promote_type(scalartype(rkcq), scalartype(testfns), scalartype(trialfns));
-	Zz = Vector{Array{Tz,2}}(Q);
-	for q = 0:Q-1
+	Zz = Vector{Array{Tz,2}}(Qmax);
+	for q = 0:Qmax-1
 		# Build a temporary matrix for each eigenvalue
 		s = laplace_to_z(rho, q, Q, Δt, A, b);
 		sFactorized = diagonalizedmatrix(s);
@@ -83,7 +87,7 @@ function assemble(rkcq :: RungeKuttaConvolutionQuadrature,
 	T = real(Tz);
 	Z = zeros(T, M*p, N*p, kmax)
 	for q = 0:kmax-1
-		Z[:,:,q+1] = real(inverse_z_transform(q, rho, Q, Zz));
+		Z[:,:,q+1] = real_inverse_z_transform(q, rho, Q, Zz);
 	end
 	return Z
 

--- a/src/timedomain/rkcq.jl
+++ b/src/timedomain/rkcq.jl
@@ -1,0 +1,90 @@
+export RungeKuttaConvolutionQuadrature
+
+"""
+    RungeKuttaConvolutionQuadrature{T,N,NN}
+
+T: the value type of the basis function.
+N: the number of stages.
+NN: N*N.
+
+Performs a convolution quadrature on a laplaceKernel to represent an operator
+in time domain using an implicit Runge-Kutta method.
+
+laplaceKernel: function of the Laplace variable s that returns an IntegralOperator.
+A, b: Coefficient matrix and vectors from the Butcher tableau.
+Δt: time step.
+zTransformedTermCount: Number of terms in the inverse Z-transform.
+contourRadius: radius of circle used as integration contour for the inverse Z-transform.
+"""
+struct RungeKuttaConvolutionQuadrature{T,N,NN}
+	laplaceKernel         # function of s that returns an IntegralOperator
+	A                     :: SArray{Tuple{N,N},T,2,NN}
+	b                     :: SVector{N,T}
+	Δt                    :: T
+	zTransformedTermCount :: Int
+	contourRadius         :: T
+end
+scalartype{T,N,NN}(rkcq::RungeKuttaConvolutionQuadrature{T,N,NN}) = Complex{T};
+
+# M = H*diagm(D)*invH
+struct DiagonalizedMatrix{T,N,NN}
+	H    :: SArray{Tuple{N,N},Complex{T},2,NN}
+	invH :: SArray{Tuple{N,N},Complex{T},2,NN}
+	D    :: SVector{N,Complex{T}}
+end
+
+# M = H*diagm(D)*invH
+function diagonalizedmatrix{T,N,NN}(M :: SArray{Tuple{N,N},Complex{T},2,NN})
+	ef = eigfact(Array{Complex{T},2}(M));
+
+	efValues = SVector{N,Complex{T}}(ef.values);
+	efVectors = SArray{Tuple{N,N},Complex{T},2,NN}(ef.vectors);
+	return DiagonalizedMatrix(efVectors, inv(efVectors), efValues);
+end
+
+function assemble(rkcq :: RungeKuttaConvolutionQuadrature,
+                  testfns :: StagedTimeStep,
+                  trialfns :: StagedTimeStep)
+
+	laplaceKernel = rkcq.laplaceKernel;
+	A = rkcq.A;
+	b = rkcq.b;
+	Δt = rkcq.Δt;
+	Q = rkcq.zTransformedTermCount;
+	rho = rkcq.contourRadius;
+	p = length(b); # stage count
+
+	test_spatial_basis  = testfns.spatialBasis;
+	trial_spatial_basis = trialfns.spatialBasis;
+
+	# Compute the Z transformed sequence
+	M = numfunctions(test_spatial_basis);
+	N = numfunctions(trial_spatial_basis);
+	Tz = promote_type(scalartype(rkcq), scalartype(testfns), scalartype(trialfns));
+	Zz = Vector{Array{Tz,2}}(Q);
+	for q = 0:Q-1
+		# Build a temporary matrix for each eigenvalue
+		s = laplace_to_z(rho, q, Q, Δt, A, b);
+		sFactorized = diagonalizedmatrix(s);
+		blocksEigenvalues = [assemble(laplaceKernel(sD), test_spatial_basis, trial_spatial_basis) for sD in sFactorized.D];
+		Zz[q+1] = zeros(Tz, M*p, N*p)
+
+		# Compute the Z transformed matrix by block
+		for m = 1:M
+			for n = 1:N
+				D = SVector{p,Tz}([blocksEigenvalues[i][m,n] for i in 1:p])
+				Zz[q+1][(m-1)*p+(1:p),(n-1)*p+(1:p)] = sFactorized.H * diagm(D) * sFactorized.invH;
+			end
+		end
+	end
+
+	# return the inverse Z transform
+	kmax = Q;
+	T = real(Tz);
+	Z = zeros(T, M*p, N*p, kmax)
+	for q = 0:kmax-1
+		Z[:,:,q+1] = real(inverse_z_transform(q, rho, Q, Zz));
+	end
+	return Z
+
+end

--- a/src/timedomain/tdexcitation.jl
+++ b/src/timedomain/tdexcitation.jl
@@ -50,6 +50,19 @@ function assemble(exc::TDFunctional, testST)
     return Z
 end
 
+function assemble(exc::TDFunctional, testST::StagedTimeStep)
+    stageCount = length(testST.c);
+    spatialBasis = testST.spatialBasis;
+    Nt = testST.Nt;
+    Δt = testST.Δt;
+    Z = zeros(eltype(exc), numfunctions(spatialBasis) * stageCount, Nt);
+    for i = 1:stageCount
+        store(v,m,k) = (Z[(m-1)*stageCount+i,k] += v);
+        tbsd = TimeBasisDeltaShifted(timebasisdelta(Δt, Nt), testST.c[i]);
+        assemble!(exc, spatialBasis ⊗ tbsd, store);
+    end
+    return Z;
+end
 
 function assemble!(exc::TDFunctional, testST, store)
 

--- a/src/timedomain/zdomain.jl
+++ b/src/timedomain/zdomain.jl
@@ -1,0 +1,23 @@
+export laplace_to_z, inverse_z_transform;
+
+"""
+    laplace_to_z(rho, n, N, dt, A, b)
+
+Returns the complex matrix valued Laplace variable s that correspond to the
+variable z = rho*exp(2*im*pi*n/N) for a given Butcher tableau (A,b,c) and a time step dt.
+"""
+function laplace_to_z(rho, n, N, dt, A, b)
+	z = rho * exp(2*im*pi*n/N);
+	s = inv(dt * (A + ones(b) * b' / (z-1)));
+	return s;
+end
+
+"""
+    inverse_z_transform(k, rho, N, X)
+
+Returns the k-th term of the inverse z-transform. X is an array of the z-transform
+evaluated in the points z=rho*exp(2*im*pi*n/N) for n in 0:(N-1).
+"""
+function inverse_z_transform{T}(k, rho, N, X::AbstractArray{T,1})
+	return ((rho^k) / N) * sum(n -> X[n+1] * exp(2*im*pi*k*n/N), 0:(N-1));
+end

--- a/src/timedomain/zdomain.jl
+++ b/src/timedomain/zdomain.jl
@@ -1,4 +1,4 @@
-export laplace_to_z, inverse_z_transform;
+export laplace_to_z, inverse_z_transform, real_inverse_z_transform;
 
 """
     laplace_to_z(rho, n, N, dt, A, b)
@@ -20,4 +20,19 @@ evaluated in the points z=rho*exp(2*im*pi*n/N) for n in 0:(N-1).
 """
 function inverse_z_transform{T}(k, rho, N, X::AbstractArray{T,1})
 	return ((rho^k) / N) * sum(n -> X[n+1] * exp(2*im*pi*k*n/N), 0:(N-1));
+end
+
+"""
+    real_inverse_z_transform(k, rho, N, X)
+
+Returns the k-th term of the inverse z-transform.
+It is assumed that X[n+1] = conj(X[N-n]) for each n in 1:(N-1)
+so that Nmax = N/2+1 or (N+1)/2 (resp. if N%2==0 or N%2==1) terms are used in X
+X is an array of the z-transform
+evaluated in the points z=rho*exp(2*im*pi*n/N) for n in 0:(Nmax-1).
+"""
+function real_inverse_z_transform{T}(k, rho, N, X::AbstractArray{T,1})
+	Nmax = (N+1)>>1;
+	realTerms = (N%2==0) ? real(X[1]) + (-1)^k * real(X[Nmax+1]) : real(X[1]);
+	return ((rho^k) / N) * (realTerms + 2*sum(n -> real(X[n+1] * exp(2*im*pi*k*n/N)), 1:(Nmax-1)));
 end

--- a/src/utils/butchertableau.jl
+++ b/src/utils/butchertableau.jl
@@ -1,0 +1,31 @@
+using StaticArrays
+
+export butcher_tableau_radau_2stages
+export butcher_tableau_radau_3stages
+
+"""
+    butcher_tableau_radau_2stages()
+
+Returns (A,b,c) corresponding to the Butcher tableau for the 2 stage Radau IIA scheme.
+"""
+function butcher_tableau_radau_2stages()
+	A = @SMatrix [5/12   -1/12
+	              3/4    1/4];
+	b = @SVector [3/4, 1/4];
+	c = @SVector [1/3, 1.0];
+	return (A, b, c);
+end
+
+"""
+    butcher_tableau_radau_3stages()
+
+Returns (A,b,c) corresponding to the Butcher tableau for the 3 stage Radau IIA scheme.
+"""
+function butcher_tableau_radau_3stages()
+	A = @SMatrix [(88.0-7.0*sqrt(6.0))/360.0       (296.0-169.0*sqrt(6.0))/1800.0   (-2.0+3.0*sqrt(6.0))/225.0
+	              (296.0+169.0*sqrt(6.0))/1800.0   (88.0+7.0*sqrt(6.0))/360.0       (-2.0-3.0*sqrt(6.0))/225.0
+	              (16.0-sqrt(6.0))/36.0            (16.0+sqrt(6.0))/36.0             1/9];
+	b = @SVector [(16.0-sqrt(6.0))/36.0,    (16.0+sqrt(6.0))/36.0,    1/9];
+	c = @SVector [(4.0-sqrt(6.0))/10.0,     (4.0+sqrt(6.0))/10.0,     1.0];
+	return (A, b, c);
+end


### PR DESCRIPTION
I have mainly added 
+ Butcher tableaux for the IRK scheme in utils/butchertableau.jl
+ Inverse Z transform in timedomain/zdomain.jl
+ A "staged time step" basis function in bases/stagedtimestep.jl
+ A TimeBasisDeltaShifted in bases/timebasis.jl that correspond to a TimeBasisDelta with a time shift which is a helper to test the RHS at each stage of the time step in timedomain/tdexcitation.jl.
+ The convolution quadrature "Operator" and its assemble function in timedomain/rkcq.jl
+ An example in examples/tdefie_irk.jl