### PR TITLE
Exporting MWDoubleLayerField3D

### DIFF
--- a/src/BEAST.jl
+++ b/src/BEAST.jl
@@ -56,7 +56,7 @@ export MWDoubleLayer3D
 export PlaneWaveMW
 export TangTraceMW, CrossTraceMW
 export curl
-export MWSingleLayerField3D
+export MWSingleLayerField3D, MWDoubleLayerField3D
 export SingleLayerTrace
 export DoubleLayerRotatedMW3D
 export MWSingleLayerPotential3D


### PR DESCRIPTION
Hi, exporting MWDoubleLayerField3D would be helpful for computing the magnetic near field.