### PR TITLE
Fix of the far field computation of Maxwell dipole

### DIFF
--- a/src/maxwell/mwexc.jl
+++ b/src/maxwell/mwexc.jl
@@ -86,14 +86,16 @@ function (d::DipoleMW)(x; isfarfield=false)
     k = d.wavenumber
     x_0 = d.location
     p = d.orientation
-    r = norm(x-x_0)
-    n = (x - x_0)/r
     if isfarfield
       # postfactor (4*π*im)/k to be consistent with BEAST far field computation
-      # and, of course, omitted exp(-im*k*r)/r factor in (9.19)
-      # of Jackson's Classical Electrodynamics
-      return k^2/(4*π)*cross(cross(n,p),n)*(4*π*im)/k
+      # and, of course, adapted phase factor exp(im*k*dot(n,x_0)) with
+      # respect to (9.19) of Jackson's Classical Electrodynamics
+      r = norm(x)
+      n = x/r
+      return cross(cross(n,1/(4*π)*(k^2*cross(cross(n,p),n))*exp(im*k*dot(n,x_0))*(4*π*im)/k),n)
     else
+      r = norm(x-x_0)
+      n = (x - x_0)/r
       return 1/(4*π)*exp(-im*k*r)*(k^2/r*cross(cross(n,p),n) + 
               (1/r^3 + im*k/r^2)*(3*n*dot(n,p) - p))
     end
@@ -103,12 +105,14 @@ function (d::curlDipoleMW)(x; isfarfield=false)
     k = d.wavenumber
     x_0 = d.location
     p = d.orientation
-    r = norm(x-x_0)
-    n =  (x - x_0)/r
     if isfarfield
       # postfactor (4*π*im)/k to be consistent with BEAST far field computation
-      return (-im*k)*k^2/(4*π)*cross(n,p)*(4*π*im)/k
+      r = norm(x)
+      n = x/r
+      return (-im*k)*k^2/(4*π)*cross(n,p)*(4*π*im)/k*exp(im*k*dot(n,x_0))
     else
+      r = norm(x-x_0)
+      n =  (x - x_0)/r
       return -im*(k^3)/(4*π)*cross(n,p)*exp(-im*k*r)/r*(1 + 1/(im*k*r))
     end
 end

--- a/test/test_dipole.jl
+++ b/test/test_dipole.jl
@@ -15,7 +15,7 @@ k = 2*π/λ
 η = sqrt(μ/ε)
 
 a = 1
-Γ_orig = CompScienceMeshes.meshcuboid(a,a,a,0.2)
+Γ_orig = CompScienceMeshes.meshcuboid(a,a,a,0.1)
 Γ = translate(Γ_orig,SVector(-a/2,-a/2,-a/2))
 
 Φ, Θ = [0.0], range(0,stop=π,length=100)
@@ -24,7 +24,7 @@ pts = [point(cos(ϕ)*sin(θ), sin(ϕ)*sin(θ), cos(θ)) for ϕ in Φ for θ in �
 # This is an electric dipole
 # The pre-factor (1/ε) is used to resemble 
 # (9.18) in Jackson's Classical Electrodynamics
-E = (1/ε) * dipolemw3d(location=SVector(0,0,0), 
+E = (1/ε) * dipolemw3d(location=SVector(0.4,0.2,0), 
                        orientation=1e-9.*SVector(0.5,0.5,0), 
                        wavenumber=k)
 
@@ -51,7 +51,7 @@ ff_E_EFIE = potential(MWFarField3D(wavenumber=k), pts, j_EFIE, X)
 
 @test norm(nf_E_EFIE - E.(pts))/norm(E.(pts)) ≈ 0 atol=0.01
 @test norm(nf_H_EFIE - H.(pts))/norm(H.(pts)) ≈ 0 atol=0.01
-@test norm(ff_E_EFIE - E.(pts, isfarfield=true))/norm(E.(pts, isfarfield=true)) ≈ 0 atol=0.01
+@test norm(ff_E_EFIE - E.(pts, isfarfield=true))/norm(E.(pts, isfarfield=true)) ≈ 0 atol=0.001
 
 K_bc = Matrix(assemble(𝓚,Y,X))
 G_nxbc_rt = Matrix(assemble(𝓝,Y,X))
@@ -67,7 +67,7 @@ ff_E_BCMFIE = potential(MWFarField3D(wavenumber=k), pts, j_BCMFIE, X)
 @test norm(nf_H_BCMFIE - H.(pts))/norm(H.(pts)) ≈ 0 atol=0.01
 @test norm(ff_E_BCMFIE - E.(pts, isfarfield=true))/norm(E.(pts, isfarfield=true)) ≈ 0 atol=0.01
 
-H = dipolemw3d(location=SVector(0,0,0), 
+H = dipolemw3d(location=SVector(0.0,0.0,0.3), 
                orientation=1e-9.*SVector(0.5,0.5,0), 
                wavenumber=k)
 
@@ -100,6 +100,7 @@ nf_E_BCMFIE = potential(MWSingleLayerField3D(wavenumber=k), pts, j_BCMFIE, X)
 nf_H_BCMFIE = potential(BEAST.MWDoubleLayerField3D(wavenumber=k), pts, j_BCMFIE, X) ./ η
 ff_E_BCMFIE = potential(MWFarField3D(wavenumber=k), pts, j_BCMFIE, X)
 
+@test norm(j_BCMFIE - j_EFIE)/norm(j_EFIE) ≈ 0 atol=0.02
 @test norm(nf_E_BCMFIE - E.(pts))/norm(E.(pts)) ≈ 0 atol=0.01
 @test norm(nf_H_BCMFIE - H.(pts))/norm(H.(pts)) ≈ 0 atol=0.01
 @test norm(ff_E_BCMFIE - E.(pts, isfarfield=true))/norm(E.(pts, isfarfield=true)) ≈ 0 atol=0.01


### PR DESCRIPTION
The previous formula assumed that the dipole is located in
the origin.

- Now the phase-term is correctly included
- Also the n x ( ) x n operation is performed stripping away the radial
  component.