### PR TITLE
Feature/pass quadstrat 2

### DIFF
--- a/src/excitation.jl
+++ b/src/excitation.jl
@@ -11,24 +11,27 @@ quadrule(fn::Functional, refs, p, cell, qd) = qd[1,p]
 Assemble the vector of test coefficients corresponding to functional
 `fn` and test functions `tfs`.
 """
-function assemble(field::Functional, tfs)
+function assemble(field::Functional, tfs; quaddata=quaddata, quadrule=quadrule)
 
     b = zeros(ComplexF64, numfunctions(tfs))
     store(v,m) = (b[m] += v)
-    assemble!(field, tfs, store)
+    assemble!(field, tfs, store, quaddata=quaddata, quadrule=quadrule)
     return b
 end
 
-function assemble!(field::Functional, tfs::DirectProductSpace, store)
+function assemble!(field::Functional, tfs::DirectProductSpace, store;
+    quaddata=quaddata, quadrule=quadrule)
+
     I = Int[0]
     for s in tfs.factors push!(I, last(I) + numfunctions(s)) end
     for (i,s) in enumerate(tfs.factors)
         store1(v,m) = store(v, m + I[i])
-        assemble!(field, s, store1)
+        assemble!(field, s, store1, quaddata=quaddata, quadrule=quadrule)
     end
 end
 
-function assemble!(field::Functional, tfs::Space, store)
+function assemble!(field::Functional, tfs::Space, store;
+    quaddata=quaddata, quadrule=quadrule)
 
     tels, tad = assemblydata(tfs)
 
@@ -51,7 +54,8 @@ function assemble!(field::Functional, tfs::Space, store)
 
 end
 
-function assemble!(field::Functional, tfs::subdBasis, store)
+function assemble!(field::Functional, tfs::subdBasis, store;
+    quaddata=quaddata, quadrule=quadrule)
 
     tels, tad = assemblydata(tfs)
 

--- a/src/integralop.jl
+++ b/src/integralop.jl
@@ -158,17 +158,18 @@ end
 
 
 
-function blockassembler(biop::IntegralOperator, tfs::Space, bfs::Space)
+function blockassembler(biop::IntegralOperator, tfs::Space, bfs::Space;
+                        quaddata=quaddata, quadrule=quadrule)
 
     test_elements, test_assembly_data,
         trial_elements, trial_assembly_data,
-        quadrature_data, zlocals = assembleblock_primer(biop, tfs, bfs)
+        quadrature_data, zlocals = assembleblock_primer(biop, tfs, bfs, quaddata=quaddata)
 
     return function f(test_ids, trial_ids, store)
         assembleblock_body!(biop,
             tfs, test_ids,   test_elements,  test_assembly_data,
             bfs, trial_ids, trial_elements, trial_assembly_data,
-            quadrature_data, zlocals, store)
+            quadrature_data, zlocals, store, quadrule=quadrule)
     end
 end
 
@@ -194,7 +195,7 @@ function assembleblock!(biop::IntegralOperator, tfs::Space, bfs::Space, store)
 end
 
 
-function assembleblock_primer(biop, tfs, bfs)
+function assembleblock_primer(biop, tfs, bfs; quaddata=quaddata)
 
     test_elements, tad = assemblydata(tfs)
     bsis_elements, bad = assemblydata(bfs)
@@ -216,7 +217,7 @@ end
 function assembleblock_body!(biop::IntegralOperator,
         tfs, test_ids, test_elements, test_assembly_data,
         bfs, trial_ids, bsis_elements, trial_assembly_data,
-        quadrature_data, zlocals, store)
+        quadrature_data, zlocals, store; quadrule=quadrule)
 
     test_shapes  = refspace(tfs)
     trial_shapes = refspace(bfs)

--- a/src/integralop.jl
+++ b/src/integralop.jl
@@ -65,7 +65,8 @@ elements(sp::Space) = elements(geometry(sp))
 
 Computes the matrix of operator biop wrt the finite element spaces tfs and bfs
 """
-function assemblechunk!(biop::IntegralOperator, tfs::Space, bfs::Space, store)
+function assemblechunk!(biop::IntegralOperator, tfs::Space, bfs::Space, store;
+        quaddata=quaddata, quadrule=quadrule)
 
     test_elements, tad = assemblydata(tfs)
     bsis_elements, bad = assemblydata(bfs)
@@ -80,13 +81,13 @@ function assemblechunk!(biop::IntegralOperator, tfs::Space, bfs::Space, store)
         assemblechunk_body!(biop,
             tshapes, test_elements, tad,
             bshapes, bsis_elements, bad,
-            qd, zlocal, store)
+            qd, zlocal, store, quadrule=quadrule)
     else
         @info "assemblechunk for nested meshes"
         assemblechunk_body_nested_meshes!(biop,
             tshapes, test_elements, tad,
             bshapes, bsis_elements, bad,
-            qd, zlocal, store)
+            qd, zlocal, store, quadrule=quadrule)
     end
 end
 
@@ -94,7 +95,7 @@ end
 function assemblechunk_body!(biop,
         test_shapes, test_elements, test_assembly_data,
         trial_shapes, trial_elements, trial_assembly_data,
-        qd, zlocal, store)
+        qd, zlocal, store; quadrule=quadrule)
 
     myid = Threads.threadid()
     myid == 1 && print("dots out of 10: ")
@@ -129,7 +130,7 @@ end
 function assemblechunk_body_nested_meshes!(biop,
         test_shapes, test_elements, test_assembly_data,
         trial_shapes, trial_elements, trial_assembly_data,
-        qd, zlocal, store)
+        qd, zlocal, store; quadrule=quadrule)
 
     myid = Threads.threadid()
     myid == 1 && print("dots out of 10: ")
@@ -159,7 +160,7 @@ end
 
 
 function blockassembler(biop::IntegralOperator, tfs::Space, bfs::Space;
-                        quaddata=quaddata, quadrule=quadrule)
+        quaddata=quaddata, quadrule=quadrule)
 
     test_elements, test_assembly_data,
         trial_elements, trial_assembly_data,
@@ -174,16 +175,19 @@ function blockassembler(biop::IntegralOperator, tfs::Space, bfs::Space;
 end
 
 
-function assembleblock(operator::AbstractOperator, test_functions, trial_functions)
+function assembleblock(operator::AbstractOperator, test_functions, trial_functions;
+        quaddata=quaddata, quadrule=quadrule)
     Z, store = allocatestorage(operator, test_functions, trial_functions)
-    assembleblock!(operator, test_functions, trial_functions, store)
+    assembleblock!(operator, test_functions, trial_functions, store, 
+        quaddata=quaddata, quadrule=quadrule)
     sdata(Z)
 end
 
-function assembleblock!(biop::IntegralOperator, tfs::Space, bfs::Space, store)
+function assembleblock!(biop::IntegralOperator, tfs::Space, bfs::Space, store;
+        quaddata=quaddata, quadrule=quadrule)
 
     test_elements, tad, trial_elements, bad, quadrature_data, zlocals =
-        assembleblock_primer(biop, tfs, bfs)
+        assembleblock_primer(biop, tfs, bfs, quaddata=quaddata)
 
     active_test_dofs  = collect(1:numfunctions(tfs))
     active_trial_dofs = collect(1:numfunctions(bfs))
@@ -191,7 +195,7 @@ function assembleblock!(biop::IntegralOperator, tfs::Space, bfs::Space, store)
     assembleblock_body!(biop,
         tfs, active_test_dofs, test_elements, tad,
         bfs, active_trial_dofs, trial_elements, bad,
-        quadrature_data, zlocals, store)
+        quadrature_data, zlocals, store, quadrule=quadrule)
 end
 
 
@@ -261,7 +265,8 @@ function assembleblock_body!(biop::IntegralOperator,
 end end end end end end end
 
 
-function assemblerow!(biop::IntegralOperator, test_functions::Space, trial_functions::Space, store)
+function assemblerow!(biop::IntegralOperator, test_functions::Space, trial_functions::Space, store;
+        quaddata=quaddata, quadrule=quadrule)
 
     test_elements = elements(geometry(test_functions))
     trial_elements, trial_assembly_data = assemblydata(trial_functions)
@@ -282,14 +287,14 @@ function assemblerow!(biop::IntegralOperator, test_functions::Space, trial_funct
     assemblerow_body!(biop,
         test_functions, test_elements, test_shapes,
         trial_assembly_data, trial_elements, trial_shapes,
-        zlocal, quadrature_data, store)
+        zlocal, quadrature_data, store, quadrule=quadrule)
 end
 
 
 function assemblerow_body!(biop,
     test_functions, test_elements, test_shapes,
     trial_assembly_data, trial_elements, trial_shapes,
-    zlocal, quadrature_data, store)
+    zlocal, quadrature_data, store; quadrule=quadrule)
 
     test_function = test_functions.fns[1]
     for shape in test_function
@@ -309,7 +314,8 @@ function assemblerow_body!(biop,
 end end end end end
 
 
-function assemblecol!(biop::IntegralOperator, test_functions::Space, trial_functions::Space, store)
+function assemblecol!(biop::IntegralOperator, test_functions::Space, trial_functions::Space, store;
+        quaddata=quaddata, quadrule=quadrule)
 
     test_elements, test_assembly_data = assemblydata(test_functions)
     trial_elements = elements(geometry(trial_functions))
@@ -331,14 +337,14 @@ function assemblecol!(biop::IntegralOperator, test_functions::Space, trial_funct
     assemblecol_body!(biop,
         test_assembly_data, test_elements,  test_shapes,
         trial_functions,   trial_elements, trial_shapes,
-        zlocal, quadrature_data, store)
+        zlocal, quadrature_data, store, quadrule=quadrule)
 end
 
 
 function assemblecol_body!(biop,
     test_assembly_data, test_elements, test_shapes,
     trial_functions, trial_elements, trial_shapes,
-    zlocal, quadrature_data, store)
+    zlocal, quadrature_data, store; quadrule=quadrule)
 
     trial_function = trial_functions.fns[1]
     for shape in trial_function

--- a/src/localop.jl
+++ b/src/localop.jl
@@ -62,7 +62,7 @@ function allocatestorage(op::LocalOperator, test_functions, trial_functions,
 end
 
 function assemble!(biop::LocalOperator, tfs::Space, bfs::Space, store,
-    threading::Type{Threading{:multi}})
+    threading::Type{Threading{:multi}}; quaddata=quaddata, quadrule=quadrule)
 
     if geometry(tfs) == geometry(bfs)
         return assemble_local_matched!(biop, tfs, bfs, store)
@@ -75,7 +75,8 @@ function assemble!(biop::LocalOperator, tfs::Space, bfs::Space, store,
     return assemble_local_mixed!(biop, tfs, bfs, store)
 end
 
-function assemble_local_matched!(biop::LocalOperator, tfs::Space, bfs::Space, store)
+function assemble_local_matched!(biop::LocalOperator, tfs::Space, bfs::Space, store;
+        quaddata=quaddata, quadrule=quadrule)
 
     tels, tad, ta2g = assemblydata(tfs)
     bels, bad, ba2g = assemblydata(bfs)
@@ -103,7 +104,8 @@ function assemble_local_matched!(biop::LocalOperator, tfs::Space, bfs::Space, st
 end end end end
 
 
-function assemble_local_refines!(biop::LocalOperator, tfs::Space, bfs::Space, store)
+function assemble_local_refines!(biop::LocalOperator, tfs::Space, bfs::Space, store;
+        quaddata=quaddata, quadrule=quadrule)
 
     println("Using 'refines' algorithm for local assembly:")
 
@@ -167,7 +169,8 @@ function assemble_local_refines!(biop::LocalOperator, tfs::Space, bfs::Space, st
 
 end
 
-function assemble_local_matched!(biop::LocalOperator, tfs::subdBasis, bfs::subdBasis, store)
+function assemble_local_matched!(biop::LocalOperator, tfs::subdBasis, bfs::subdBasis, store;
+        quaddata=quaddata, quadrule=quadrule)
 
     tels, tad = assemblydata(tfs)
     bels, bad = assemblydata(bfs)
@@ -223,7 +226,8 @@ end
 
 For use when basis and test functions are defined on different meshes
 """
-function assemble_local_mixed!(biop::LocalOperator, tfs::Space, bfs::Space, store)
+function assemble_local_mixed!(biop::LocalOperator, tfs::Space, bfs::Space, store;
+        quaddata=quaddata, quadrule=quadrule)
 
     tol = sqrt(eps(Float64))
 

--- a/src/maxwell/mwops.jl
+++ b/src/maxwell/mwops.jl
@@ -100,9 +100,6 @@ function quaddata(op::MaxwellOperator3D,
     return (tpoints=tqd, bpoints=bqd, gausslegendre=leg)
 end
 
-
-
-
 # use Union type so this code can be shared between the operator
 # and its regular part.
 MWSL3DGen = Union{MWSingleLayer3D,MWSingleLayer3DReg}

--- a/src/maxwell/timedomain/mwtdops.jl
+++ b/src/maxwell/timedomain/mwtdops.jl
@@ -137,7 +137,7 @@ end
 # end
 
 function assemble!(dl::MWDoubleLayerTDIO, W::SpaceTimeBasis, V::SpaceTimeBasis, store,
-    threading=Threading{:multi})
+    threading=Threading{:multi}; quaddata=quaddata, quadrule=quadrule)
 
 	X, T = spatialbasis(W), temporalbasis(W)
 	Y, U = spatialbasis(V), temporalbasis(V)

--- a/src/timedomain/tdintegralop.jl
+++ b/src/timedomain/tdintegralop.jl
@@ -129,7 +129,7 @@ function allocatestorage(op::RetardedPotential, testST, basisST,
 end
 
 function assemble!(op::LinearCombinationOfOperators, tfs::SpaceTimeBasis, bfs::SpaceTimeBasis, store,
-    threading=Threading{:multi})
+    threading=Threading{:multi}; quaddata=quaddata, quadrule=quadrule)
 
     for (a,A) in zip(op.coeffs, op.ops)
         store1(v,m,n,k) = store(a*v,m,n,k)
@@ -138,7 +138,7 @@ function assemble!(op::LinearCombinationOfOperators, tfs::SpaceTimeBasis, bfs::S
 end
 
 function assemble!(op::RetardedPotential, testST, trialST, store,
-    threading=Threading{:multi})
+    threading=Threading{:multi}; quaddata=quaddata, quadrule=quadrule)
 
 	Y, S = spatialbasis(testST), temporalbasis(testST)
 
@@ -158,7 +158,8 @@ function assemble!(op::RetardedPotential, testST, trialST, store,
 	assemble_chunk!(op, testST, trialST, store)
 end
 
-function assemble_chunk!(op::RetardedPotential, testST, trialST, store)
+function assemble_chunk!(op::RetardedPotential, testST, trialST, store; 
+    quaddata=quaddata, quadrule=quadrule)
 
 	myid = Threads.threadid()
 

--- a/test/test_quadrature.jl
+++ b/test/test_quadrature.jl
@@ -1,0 +1,90 @@
+using Test
+
+using CompScienceMeshes
+using BEAST
+using StaticArrays
+using LinearAlgebra
+
+c = 3e8
+μ = 4*π*1e-7
+ε = 1/(μ*c^2)
+f = 5e7
+λ = c/f
+k = 2*π/λ
+ω = k*c
+η = sqrt(μ/ε)
+
+a = 1
+Γ_orig = CompScienceMeshes.meshcuboid(a,a,a,0.1)
+Γ = translate(Γ_orig,SVector(-a/2,-a/2,-a/2))
+
+Φ, Θ = [0.0], range(0,stop=π,length=100)
+pts = [point(cos(ϕ)*sin(θ), sin(ϕ)*sin(θ), cos(θ)) for ϕ in Φ for θ in Θ]
+
+# This is an electric dipole
+# The pre-factor (1/ε) is used to resemble 
+# (9.18) in Jackson's Classical Electrodynamics
+E = (1/ε) * dipolemw3d(location=SVector(0.4,0.2,0), 
+                       orientation=1e-9.*SVector(0.5,0.5,0), 
+                       wavenumber=k)
+
+n = BEAST.NormalVector()
+
+𝒆 = (n × E) × n
+H = (-1/(im*μ*ω))*curl(E)
+𝒉 = (n × H) × n
+
+𝓣 = Maxwell3D.singlelayer(wavenumber=k)
+
+X = raviartthomas(Γ)
+
+T = Matrix(assemble(𝓣,X,X))
+e = Vector(assemble(𝒆,X))
+j_EFIE = T\e
+
+nf_E_EFIE = potential(MWSingleLayerField3D(wavenumber=k), pts, j_EFIE, X)
+nf_H_EFIE = potential(BEAST.MWDoubleLayerField3D(wavenumber=k), pts, j_EFIE, X) ./ η
+ff_E_EFIE = potential(MWFarField3D(wavenumber=k), pts, j_EFIE, X)
+
+accuracy_default_quadrature_nf_e = norm(nf_E_EFIE - E.(pts))/norm(E.(pts))
+accuracy_default_quadrature_nf_h = norm(nf_H_EFIE - H.(pts))/norm(H.(pts))
+accuracy_default_quadrature_ff_e = 
+    norm(ff_E_EFIE - E.(pts, isfarfield=true))/norm(E.(pts, isfarfield=true))
+
+function fastquaddata(op::BEAST.MaxwellOperator3D,
+    test_local_space::BEAST.RefSpace, trial_local_space::BEAST.RefSpace,
+    test_charts, trial_charts)
+
+    a, b = 0.0, 1.0
+    # CommonVertex, CommonEdge, CommonFace rules
+    println("Fast quadrule is called")
+    tqd = quadpoints(test_local_space, test_charts, (1,2))
+    bqd = quadpoints(trial_local_space, trial_charts, (1,2))
+    leg = (BEAST._legendre(3,a,b), BEAST._legendre(4,a,b), BEAST._legendre(5,a,b),)
+
+    return (tpoints=tqd, bpoints=bqd, gausslegendre=leg)
+end
+
+function fastquaddata(fn::BEAST.Functional, refs, cells) 
+    println("Fast RHS quadrature")
+    return quadpoints(refs, cells, [1])
+end
+
+
+fastT = Matrix(assemble(𝓣,X,X, quaddata=fastquaddata))
+faste = Vector(assemble(𝒆,X, quaddata=fastquaddata))
+fastj_EFIE = fastT\faste
+
+fastnf_E_EFIE = potential(MWSingleLayerField3D(wavenumber=k), pts, fastj_EFIE, X)
+fastnf_H_EFIE = potential(BEAST.MWDoubleLayerField3D(wavenumber=k), pts, fastj_EFIE, X) ./ η
+fastff_E_EFIE = potential(MWFarField3D(wavenumber=k), pts, fastj_EFIE, X)
+
+accuracy_fast_quadrature_nf_e = norm(fastnf_E_EFIE - E.(pts))/norm(E.(pts))
+accuracy_fast_quadrature_nf_h = norm(fastnf_H_EFIE - H.(pts))/norm(H.(pts))
+accuracy_fast_quadrature_ff_e = 
+    norm(fastff_E_EFIE - E.(pts, isfarfield=true))/norm(E.(pts, isfarfield=true))
+
+@test accuracy_fast_quadrature_nf_e > accuracy_default_quadrature_nf_e
+@test accuracy_fast_quadrature_nf_h > accuracy_default_quadrature_nf_h
+@test accuracy_fast_quadrature_ff_e > accuracy_default_quadrature_ff_e
+


### PR DESCRIPTION
This branch allows to pass to the assembler routines individual quaddata and quadrule functions. This is useful in the context of fast methods such as the adaptive cross approximation, as elements that are well-separate in the FMM sense can be typically discretized with even fewer Gaussian quadrature points.

This feature branch should probably be merged after my bugfix branch regarding zlocal and multithreading to avoid merge conflicts.