### PR TITLE
Bugfix/passthru of quadstrat

### DIFF
--- a/src/integralop.jl
+++ b/src/integralop.jl
@@ -154,7 +154,7 @@ function assemblechunk_body_nested_meshes!(biop,
 
             fill!(zlocal, 0)
             qrule = quadrule(biop, test_shapes, trial_shapes, p, tcell, q, bcell, qd, quadstrat)
-            momintegrals_nested!(biop, test_shapes, trial_shapes, tcell, bcell, zlocal, qrule)
+            momintegrals_nested!(biop, test_shapes, trial_shapes, tcell, bcell, zlocal, qrule, quadstrat)
             I = length(test_assembly_data[p])
             J = length(trial_assembly_data[q])
             for j in 1 : J, i in 1 : I
@@ -188,7 +188,7 @@ for (p,tcell) in enumerate(test_elements)
 
         fill!(zlocal, 0)
         qrule = quadrule(biop, test_shapes, trial_shapes, p, tcell, q, bcell, qd, quadstrat)
-        momintegrals_trial_refines_test!(biop, test_shapes, trial_shapes, tcell, bcell, zlocal, qrule)
+        momintegrals_trial_refines_test!(biop, test_shapes, trial_shapes, tcell, bcell, zlocal, qrule, quadstrat)
         I = length(test_assembly_data[p])
         J = length(trial_assembly_data[q])
         for j in 1 : J, i in 1 : I
@@ -362,7 +362,7 @@ function assembleblock_body_nested!(biop::IntegralOperator,
 
             fill!(zlocals[Threads.threadid()], 0)
             qrule = quadrule(biop, test_shapes, trial_shapes, p, tcell, q, bcell, quadrature_data, quadstrat)
-            momintegrals_nested!(biop, test_shapes, trial_shapes, tcell, bcell, zlocals[Threads.threadid()], qrule)
+            momintegrals_nested!(biop, test_shapes, trial_shapes, tcell, bcell, zlocals[Threads.threadid()], qrule, quadstrat)
 
             for j in 1 : size(zlocals[Threads.threadid()],2)
                 for i in 1 : size(zlocals[Threads.threadid()],1)

--- a/src/maxwell/sauterschwabints_rt.jl
+++ b/src/maxwell/sauterschwabints_rt.jl
@@ -87,7 +87,7 @@ end
 const MWOperator3D = Union{MWSingleLayer3D, MWDoubleLayer3D}
 function momintegrals_nested!(op::MWOperator3D,
     test_local_space::RTRefSpace, trial_local_space::RTRefSpace,
-    test_chart, trial_chart, out, strat::SauterSchwabStrategy)
+    test_chart, trial_chart, out, strat::SauterSchwabStrategy, quadstrat)
 
     # 1. Refine the trial_chart
     p1, p2, p3 = trial_chart.vertices
@@ -107,13 +107,12 @@ function momintegrals_nested!(op::MWOperator3D,
         simplex(ct, p3, e2),
         simplex(ct, e2, p1)]
 
-    qs = defaultquadstrat(op, test_local_space, trial_local_space)
     qd = quaddata(op, test_local_space, trial_local_space,
-        [test_chart], refined_trial_chart, qs)
+        [test_chart], refined_trial_chart, quadstrat)
 
     for (q,chart) in enumerate(refined_trial_chart)
         qr = quadrule(op, test_local_space, trial_local_space,
-            1, test_chart, q ,chart, qd, qs)
+            1, test_chart, q ,chart, qd, quadstrat)
 
         Q = restrict(trial_local_space, trial_chart, chart)
         zlocal = zero(out)
@@ -130,7 +129,7 @@ end
 
 function momintegrals_nested!(op::IntegralOperator,
     test_local_space::RefSpace, trial_local_space::RefSpace,
-    test_chart, trial_chart, out, strat)
+    test_chart, trial_chart, out, strat, quadstrat)
 
     momintegrals!(op, test_local_space, trial_local_space,
         test_chart, trial_chart, out, strat)
@@ -138,7 +137,7 @@ end
 
 function momintegrals_trial_refines_test!(op::IntegralOperator,
     test_local_space::RefSpace, trial_local_space::RefSpace,
-    test_chart, trial_chart, out, strat)
+    test_chart, trial_chart, out, strat, quadstrat)
 
     momintegrals!(op, test_local_space, trial_local_space,
         test_chart, trial_chart, out, strat)
@@ -147,7 +146,7 @@ end
 
 function momintegrals_trial_refines_test!(op::MWOperator3D,
     test_local_space::RTRefSpace, trial_local_space::RTRefSpace,
-    test_chart, trial_chart, out, strat::SauterSchwabStrategy)
+    test_chart, trial_chart, out, strat::SauterSchwabStrategy, quadstrat)
 
     # 1. Refine the test_chart
     p1, p2, p3 = test_chart.vertices
@@ -167,13 +166,12 @@ function momintegrals_trial_refines_test!(op::MWOperator3D,
         simplex(ct, p3, e2),
         simplex(ct, e2, p1)]
 
-    qs = defaultquadstrat(op, test_local_space, trial_local_space)
     qd = quaddata(op, test_local_space, trial_local_space,
-        refined_test_chart, [trial_chart], qs)
+        refined_test_chart, [trial_chart], quadstrat)
 
     for (p,chart) in enumerate(refined_test_chart)
         qr = quadrule(op, test_local_space, trial_local_space,
-            p, chart, 1, trial_chart, qd, qs)
+            p, chart, 1, trial_chart, qd, quadstrat)
 
         Q = restrict(test_local_space, test_chart, chart)
         zlocal = zero(out)

--- a/test/test_assemble_refinements.jl
+++ b/test/test_assemble_refinements.jl
@@ -30,3 +30,39 @@ K1 = assemble(Kop, X, Y)
 K2 = assemble(Kop, Y, X)
 
 @test K1[1,1] ≈ K2[1,1] rtol=1e-3
+
+# Verify that quadrature strategy is passed true
+qds(i) = BEAST.DoubleNumWiltonSauterQStrat(1,1,6,7,i,i,i,i)
+Kxy_1 = (assemble(Kop, X, Y, quadstrat=qds(1)))[1,1]
+Kxy_2 = (assemble(Kop, X, Y, quadstrat=qds(5)))[1,1]
+Kxy_3 = (assemble(Kop, X, Y, quadstrat=qds(10)))[1,1]
+
+@test 0.1 < abs(Kxy_1 - Kxy_3)/abs(Kxy_3) < 0.2
+@test 0.0008 < abs(Kxy_2 - Kxy_3)/abs(Kxy_3) < 0.0009
+
+Kyx_1 = (assemble(Kop, Y, X, quadstrat=qds(1)))[1,1]
+Kyx_2 = (assemble(Kop, Y, X, quadstrat=qds(5)))[1,1]
+Kyx_3 = (assemble(Kop, Y, X, quadstrat=qds(10)))[1,1]
+
+@test 0.2 < abs(Kyx_1 - Kyx_3)/abs(Kyx_3) < 0.3
+@test 0.0006 < abs(Kyx_2 - Kyx_3)/abs(Kyx_3) < 0.0007
+
+Γtr = translate(Γ, SVector(2.0, 0.0, 0.0))
+
+Γ2 = weld(Γ, Γtr)
+
+X2 = raviartthomas(Γ2)
+Y2 = buffachristiansen(Γ2)
+
+qds2(i) = BEAST.DoubleNumWiltonSauterQStrat(i,i,i,i,10,10,10,10)
+K2xy_1 = (assemble(Kop, X2, Y2, quadstrat=qds2(1)))[1,2]
+K2xy_2 = (assemble(Kop, X2, Y2, quadstrat=qds2(5)))[1,2]
+K2xy_3 = (assemble(Kop, X2, Y2, quadstrat=qds2(10)))[1,2]
+@test 0.06 < abs(K2xy_1 - K2xy_3)/abs(K2xy_3) < 0.07
+@test 1e-6 < abs(K2xy_2 - K2xy_3)/abs(K2xy_3) < 1e-5
+
+K2yx_1 = (assemble(Kop, Y2, X2, quadstrat=qds2(1)))[1,2]
+K2yx_2 = (assemble(Kop, Y2, X2, quadstrat=qds2(5)))[1,2]
+K2yx_3 = (assemble(Kop, Y2, X2, quadstrat=qds2(10)))[1,2]
+@test 0.06 < abs(K2yx_1 - K2yx_3)/abs(K2yx_3) < 0.07
+@test 1e-6 < abs(K2yx_2 - K2yx_3)/abs(K2yx_3) < 1e-5

--- a/test/test_ss_nested_meshes.jl
+++ b/test/test_ss_nested_meshes.jl
@@ -37,13 +37,15 @@ function BEAST.quaddata(op::BEAST.MaxwellOperator3D,
     return (tpoints=tqd, bpoints=bqd, gausslegendre=leg)
 end
 
+qs_strat = BEAST.DoubleNumWiltonSauterQStrat(1,1,6,7,10,10,10,10)
+
 sauterschwab = BEAST.SauterSchwabQuadrature.CommonFace(nothing)
 out_ss = zeros(T, numfunctions(𝒳), numfunctions(𝒳))
-BEAST.momintegrals_nested!(𝒜,𝒳,𝒳,test_chart,trial_chart,out_ss,sauterschwab)
+BEAST.momintegrals_nested!(𝒜,𝒳,𝒳,test_chart,trial_chart,out_ss,sauterschwab,qs_strat)
 
 wiltonsingext = BEAST.WiltonSERule(test_quadpoints, BEAST.DoubleQuadRule(test_quadpoints, trial_quadpoints))
 out_dw = zeros(T, numfunctions(𝒳), numfunctions(𝒳))
-BEAST.momintegrals_nested!(𝒜,𝒳,𝒳,test_chart,trial_chart,out_dw,wiltonsingext)
+BEAST.momintegrals_nested!(𝒜,𝒳,𝒳,test_chart,trial_chart,out_dw,wiltonsingext,qs_strat)
 
 @show norm(out_ss-out_dw) / norm(out_dw)
 


### PR DESCRIPTION
Currently, when BC functions are involved, not in all cases information on the quadrature strategy is passed on.

This PR ensures that when a SauterSchwab-Scenario is detected that the original quadstrat is passed on. This allows obtaining the quadrule with the correct quadrature order.