### PR TITLE
Helmholtz3D: DirichletTrace and new excitations

### DIFF
--- a/src/BEAST.jl
+++ b/src/BEAST.jl
@@ -52,8 +52,11 @@ export DoubleLayerTransposed
 export HyperSingular
 export HH3DSingleLayerTDBIO
 export HH3DDoubleLayerTDBIO
-export ∂n
+export ∂n, grad
 export HH3DHyperSingularFDBIO
+export DirichletTrace
+export HH3DMonopole, gradHH3DMonopole
+export HH3DLinearPotential
 
 export HH3DSingleLayerNear
 export HH3DDoubleLayerNear

--- a/src/helmholtz3d/hh3dexc.jl
+++ b/src/helmholtz3d/hh3dexc.jl
@@ -1,6 +1,6 @@
 
 
-struct HH3DPlaneWave{T,P} <: Functional
+struct HH3DPlaneWave{T,P}
     direction::P
     wavenumber::T
     amplitude::T
@@ -18,6 +18,118 @@ function (f::HH3DPlaneWave)(r)
     a * exp(-im*k*dot(d,r))
 end
 
+"""
+    HH3DLinearPotential
+
+A potential that linearly increases in `direction` with scaling coefficient `amplitude`.
+Its negative gradient will be a uniform vector field pointing in the opposite direction.
+"""
+struct HH3DLinearPotential{T,P}
+    direction::P
+    amplitude::T
+end
+
+function HH3DLinearPotential(; direction=SVector(1,0,0), amplitude=1.0)
+    HH3DLinearPotential(direction ./ norm(direction), amplitude)
+end
+
+function (f::HH3DLinearPotential)(r)
+    d = f.direction
+    a = f.amplitude
+    return a * dot(d, r)
+end
+
+struct gradHH3DLinearPotential{T,P}
+    direction::P
+    amplitude::T
+end
+
+function gradHH3DLinearPotential(;direction=SVector(0.0,0.0,0.0), amplitude=1.0)
+    gradHH3DLinearPotential(direction, amplitude)
+end
+
+function (f::gradHH3DLinearPotential)(r)
+    d = f.direction
+    a = f.amplitude
+
+    return a * d
+end
+
+function grad(m::HH3DLinearPotential)
+    return gradHH3DLinearPotential(m.direction, m.amplitude)
+end
+
+*(a::Number, m::HH3DLinearPotential) = HH3DLinearPotential(m.direction, a * m.amplitude)
+*(a::Number, m::gradHH3DLinearPotential) = gradHH3DLinearPotential(m.direction, a * m.amplitude)
+
+dot(::NormalVector, m::gradHH3DLinearPotential) = NormalDerivative(HH3DLinearPotential(m.direction, m.amplitude))
+
+"""
+    HH3DMonopole
+
+Potential of a monopole-type point source (e.g., of an electric charge)
+"""
+struct HH3DMonopole{T,P}
+    position::P
+    wavenumber::T
+    amplitude::T
+end
+
+function HH3DMonopole(;position=SVector(0.0,0.0,0.0), wavenumber=0.0, amplitude=1.0)
+    w, a = promote(wavenumber, amplitude)
+    HH3DMonopole(position, w, a)
+end
+
+function (f::HH3DMonopole)(r)
+    k = f.wavenumber
+    p = f.position
+    a = f.amplitude
+
+    return  a*exp(-im * k * norm(r - p)) / (norm(r - p))
+end
+
+struct gradHH3DMonopole{T,P}
+    position::P
+    wavenumber::T
+    amplitude::T
+end
+
+function gradHH3DMonopole(;position=SVector(0.0,0.0,0.0), wavenumber=0.0, amplitude=1.0)
+    w, a = promote(wavenumber, amplitude)
+    gradHH3DMonopole(position, w, a)
+end
+
+function (f::gradHH3DMonopole)(r)
+    a = f.amplitude
+    k = f.wavenumber
+    p = f.position
+    vecR = r - p
+    R = norm(vecR)
+
+    return -a * vecR * exp(-im * k * R) / R^2 * (im * k + 1 / R)
+end
+
+function grad(m::HH3DMonopole)
+    return gradHH3DMonopole(m.position, m.wavenumber, m.amplitude)
+end
+
+*(a::Number, m::HH3DMonopole) = HH3DMonopole(m.position, m.wavenumber, a * m.amplitude)
+*(a::Number, m::gradHH3DMonopole) = gradHH3DMonopole(m.position, m.wavenumber, a * m.amplitude)
+
+dot(::NormalVector, m::gradHH3DMonopole) = NormalDerivative(HH3DMonopole(m.position, m.wavenumber, m.amplitude))
+
+mutable struct DirichletTrace{F} <: Functional
+    field::F
+end
+
+function (ϕ::DirichletTrace)(p)
+    F = ϕ.field
+    x = cartesian(p)
+    return F(x)
+end
+
+integrand(::DirichletTrace, test_vals, field_vals) = dot(test_vals[1], field_vals)
+
 struct NormalDerivative{F} <: Functional
     field::F
 end
@@ -34,5 +146,19 @@ function (f::NormalDerivative{T})(manipoint) where T<:HH3DPlaneWave
     -im*k*a * dot(d,n) * exp(-im*k*dot(d,r))
 end
 
+function (f::NormalDerivative{T})(manipoint) where T<:HH3DLinearPotential
+    gradient = f.field.amplitude * f.field.direction
+    n = normal(manipoint)
+    return dot(n, gradient)
+end
+
+function (f::NormalDerivative{T})(manipoint) where T<:HH3DMonopole
+    m = f.field
+    grad_m = grad(m)
+    n = normal(manipoint)
+    r = cartesian(manipoint)
+
+    return dot(n, grad_m(r))
+end
 
 integrand(::NormalDerivative, test_vals, field_vals) = dot(test_vals[1], field_vals)

--- a/test/test_hh3d_nearfield.jl
+++ b/test/test_hh3d_nearfield.jl
@@ -4,7 +4,7 @@ using StaticArrays
 using LinearAlgebra
 using Test
 
-@testset "Helmholtz potential operators" begin
+#@testset "Helmholtz potential operators" begin
     r = 10.0
     λ = 20 * r
     k = 2 * π / λ
@@ -26,31 +26,16 @@ using Test
     pos1 = SVector(r * 1.5, 0.0, 0.0)  # positioning of point charges
     pos2 = SVector(-r * 1.5, 0.0, 0.0)
 
+    charge1 = HH3DMonopole(position=pos1, amplitude=q/(4*π*ϵ), wavenumber=k)
+    charge2 = HH3DMonopole(position=pos2, amplitude=-q/(4*π*ϵ), wavenumber=k)
+
     # Potential of point charges
-    function Φ_inc(x)
-        return q / (4 * π * ϵ) * (
-            exp(-im * k * norm(x - pos1)) / (norm(x - pos1)) -
-            exp(-im * k * norm(x - pos2)) / (norm(x - pos2))
-        )
-    end
 
-    function ∂nΦ_inc(x)
-        return -q / (4 * π * ϵ * r) * (
-            (dot(
-                x,
-                (x - pos1) * exp(-im * k * norm(x - pos1)) / (norm(x - pos1)^2) *
-                (im * k + 1 / (norm(x - pos1))),
-            )) - (dot(
-                x,
-                (x - pos2) * exp(-im * k * norm(x - pos2)) / (norm(x - pos2)^2) *
-                (im * k + 1 / (norm(x - pos2))),
-            ))
-        )
-    end
+    Φ_inc(x) = charge1(x) + charge2(x)
 
-    gD0 = assemble(ScalarTrace(Φ_inc), X0)
-    gD1 = assemble(ScalarTrace(Φ_inc), X1)
-    gN = assemble(ScalarTrace(∂nΦ_inc), X1)
+    gD0 = assemble(DirichletTrace(charge1), X0) + assemble(DirichletTrace(charge2), X0)
+    gD1 = assemble(DirichletTrace(charge1), X1) + assemble(DirichletTrace(charge2), X1)
+    gN = assemble(∂n(charge1), X1) + assemble(BEAST.n ⋅ grad(charge2), X1)
 
     G = assemble(Identity(), X1, X1)
     o = ones(numfunctions(X1))
@@ -86,17 +71,7 @@ using Test
     err_INPDL_pot = norm(pot_INPDL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
 
     # Efield(x) = - grad Φ_inc(x)
-    function Efield(x)
-        return q / (4 * π * ϵ) * (
-            (
-                (x - pos1) * exp(-im * k * norm(x - pos1)) / (norm(x - pos1)^2) *
-                (im * k + 1 / (norm(x - pos1)))
-            ) - (
-                (x - pos2) * exp(-im * k * norm(x - pos2)) / (norm(x - pos2)^2) *
-                (im * k + 1 / (norm(x - pos2)))
-            )
-        )
-    end
+    Efield(x) =  -grad(charge1)(x) + -grad(charge2)(x)
 
     field_IDPSL = -potential(HH3DDoubleLayerTransposedNear(im * k), pts, ρ_IDPSL, X0)
     field_IDPDL = potential(HH3DHyperSingularNear(im * k), pts, ρ_IDPDL, X1)
@@ -114,9 +89,12 @@ using Test
     pos1 = SVector(r * 0.5, 0.0, 0.0)
     pos2 = SVector(-r * 0.5, 0.0, 0.0)
 
-    gD0 = assemble(ScalarTrace(Φ_inc), X0)
-    gD1 = assemble(ScalarTrace(Φ_inc), X1)
-    gN = assemble(ScalarTrace(∂nΦ_inc), X1)
+    charge1 = HH3DMonopole(position=pos1, amplitude=q/(4*π*ϵ), wavenumber=k)
+    charge2 = HH3DMonopole(position=pos2, amplitude=-q/(4*π*ϵ), wavenumber=k)
+
+    gD0 = assemble(DirichletTrace(charge1), X0) + assemble(DirichletTrace(charge2), X0)
+    gD1 = assemble(DirichletTrace(charge1), X1) + assemble(DirichletTrace(charge2), X1)
+    gN = assemble(∂n(charge1), X1) + assemble(∂n(charge2), X1)
 
     G = assemble(Identity(), X1, X1)
     o = ones(numfunctions(X1))
@@ -177,4 +155,4 @@ using Test
     @test err_EDPDL_field < 0.03
     @test err_ENPSL_field < 0.01
     @test err_ENPDL_field < 0.02
-end
+#end

--- a/test/test_hh3dexc.jl
+++ b/test/test_hh3dexc.jl
@@ -16,6 +16,12 @@ for T in [Float32, Float64]
     @test v1 ≈ +1
     @test v2 ≈ -1
 
+    lp = HH3DLinearPotential(direction=point(T,0,1,0), amplitude=2.0)
+    @test lp(point(T,1,1,0)) == T(2.0)
+
+    gradlp = grad(lp)
+    @test gradlp(point(T,1,1,0)) == point(T, 0, 2, 0)
+
     import BEAST.∂n
     p = ∂n(f)
 


### PR DESCRIPTION
Helmholtz3D is now a bit closer to the Maxwell case by offering a Dirichlet Trace.

New excitations:
 - Monopole source (e.g., useful for electrostatic charges)
 - Linear potential (e.g., for uniform static fields)