### PR TITLE
Propagate novel mixed discretization handling to blockassembler

### DIFF
--- a/src/integralop.jl
+++ b/src/integralop.jl
@@ -82,9 +82,9 @@ function assemblechunk!(biop::IntegralOperator, tfs::Space, bfs::Space, store;
 
     if CompScienceMeshes.refines(tgeo, bgeo)
         assemblechunk_body_test_refines_trial!(biop,
-        tfs, test_elements, tad, tcells,
-        bfs, bsis_elements, bad, bcells,
-        qd, zlocal, store; quadstrat)
+            tfs, test_elements, tad, tcells,
+            bfs, bsis_elements, bad, bcells,
+            qd, zlocal, store; quadstrat)
     elseif CompScienceMeshes.refines(bgeo, tgeo)
         assemblechunk_body_trial_refines_test!(biop,
             tfs, test_elements, tad, tcells,
@@ -223,16 +223,26 @@ function blockassembler(biop::IntegralOperator, tfs::Space, bfs::Space;
         trial_elements, trial_assembly_data,
         quadrature_data, zlocals = assembleblock_primer(biop, tfs, bfs; quadstrat)
 
-    if !CompScienceMeshes.refines(tfs.geo, bfs.geo)
+    tgeo = geometry(tfs)
+    bgeo = geometry(bfs)
+
+    if CompScienceMeshes.refines(tgeo, bgeo)
         return (test_ids, trial_ids, store) -> begin
-            assembleblock_body!(biop,
+            assembleblock_body_test_refines_trial!(biop,
+                tfs, test_ids,   test_elements,  test_assembly_data,
+                bfs, trial_ids, trial_elements, trial_assembly_data,
+                quadrature_data, zlocals, store; quadstrat)
+        end
+    elseif CompScienceMeshes.refines(bgeo, tgeo)
+        return (test_ids, trial_ids, store) -> begin
+            assembleblock_body_trial_refines_test!(biop,
                 tfs, test_ids,   test_elements,  test_assembly_data,
                 bfs, trial_ids, trial_elements, trial_assembly_data,
                 quadrature_data, zlocals, store; quadstrat)
         end
     else
         return (test_ids, trial_ids, store) -> begin
-            assembleblock_body_nested!(biop,
+            assembleblock_body!(biop,
                 tfs, test_ids,   test_elements,  test_assembly_data,
                 bfs, trial_ids, trial_elements, trial_assembly_data,
                 quadrature_data, zlocals, store; quadstrat)
@@ -325,6 +335,110 @@ function assembleblock_body!(biop::IntegralOperator,
             qrule = quadrule(biop, test_shapes, trial_shapes, p, tcell, q, bcell, quadrature_data, quadstrat)
             momintegrals!(biop, test_shapes, trial_shapes, tcell, bcell, zlocals[Threads.threadid()], qrule)
 
+            for j in 1 : size(zlocals[Threads.threadid()],2)
+                for i in 1 : size(zlocals[Threads.threadid()],1)
+                    for (n,b) in trial_assembly_data[q,j]
+                        n′ = get(trial_id_in_blk, n, 0)
+                        n′ == 0 && continue
+                        for (m,a) in test_assembly_data[p,i]
+                            m′ = get(test_id_in_blk, m, 0)
+                            m′ == 0 && continue
+                            store(a*zlocals[Threads.threadid()][i,j]*b, m′, n′)
+end end end end end end end
+
+function assembleblock_body_trial_refines_test!(biop::IntegralOperator,
+        tfs, test_ids, test_elements, test_assembly_data,
+        bfs, trial_ids, bsis_elements, trial_assembly_data,
+        quadrature_data, zlocals, store; quadstrat)
+
+    test_shapes  = refspace(tfs)
+    trial_shapes = refspace(bfs)
+
+    # Enumerate all the active test elements
+    active_test_el_ids  = Vector{Int}()
+    active_trial_el_ids = Vector{Int}()
+
+    test_id_in_blk  = Dict{Int,Int}()
+    trial_id_in_blk = Dict{Int,Int}()
+
+    for (i,m) in enumerate(test_ids);   test_id_in_blk[m] = i; end
+    for (i,m) in enumerate(trial_ids); trial_id_in_blk[m] = i; end
+
+    for m in test_ids,  sh in tfs.fns[m]; push!(active_test_el_ids,  sh.cellid); end
+    for m in trial_ids, sh in bfs.fns[m]; push!(active_trial_el_ids, sh.cellid); end
+
+    active_test_el_ids = unique!(sort!(active_test_el_ids))
+    active_trial_el_ids = unique!(sort!(active_trial_el_ids))
+
+    @assert length(active_test_el_ids) <= length(test_elements)
+    @assert length(active_trial_el_ids) <= length(bsis_elements)
+
+    @assert maximum(active_test_el_ids) <= length(test_elements) "$(maximum(active_test_el_ids)), $(length(test_elements))"
+    @assert maximum(active_trial_el_ids) <= length(bsis_elements) "$(maximum(active_trial_el_ids)), $(length(bsis_elements))"
+
+    for p in active_test_el_ids
+        tcell = test_elements[p]
+        for q in active_trial_el_ids
+            bcell = bsis_elements[q]
+
+            fill!(zlocals[Threads.threadid()], 0)
+            qrule = quadrule(biop, test_shapes, trial_shapes, p, tcell, q, bcell, quadrature_data, quadstrat)
+            momintegrals_trial_refines_test!(zlocals[Threads.threadid()], biop,
+                tfs, p, tcell,
+                bfs, q, bcell,
+                qrule, quadstrat)
+            for j in 1 : size(zlocals[Threads.threadid()],2)
+                for i in 1 : size(zlocals[Threads.threadid()],1)
+                    for (n,b) in trial_assembly_data[q,j]
+                        n′ = get(trial_id_in_blk, n, 0)
+                        n′ == 0 && continue
+                        for (m,a) in test_assembly_data[p,i]
+                            m′ = get(test_id_in_blk, m, 0)
+                            m′ == 0 && continue
+                            store(a*zlocals[Threads.threadid()][i,j]*b, m′, n′)
+end end end end end end end
+
+function assembleblock_body_test_refines_trial!(biop::IntegralOperator,
+    tfs, test_ids, test_elements, test_assembly_data,
+    bfs, trial_ids, bsis_elements, trial_assembly_data,
+    quadrature_data, zlocals, store; quadstrat)
+
+    test_shapes  = refspace(tfs)
+    trial_shapes = refspace(bfs)
+
+    # Enumerate all the active test elements
+    active_test_el_ids  = Vector{Int}()
+    active_trial_el_ids = Vector{Int}()
+
+    test_id_in_blk  = Dict{Int,Int}()
+    trial_id_in_blk = Dict{Int,Int}()
+
+    for (i,m) in enumerate(test_ids);   test_id_in_blk[m] = i; end
+    for (i,m) in enumerate(trial_ids); trial_id_in_blk[m] = i; end
+
+    for m in test_ids,  sh in tfs.fns[m]; push!(active_test_el_ids,  sh.cellid); end
+    for m in trial_ids, sh in bfs.fns[m]; push!(active_trial_el_ids, sh.cellid); end
+
+    active_test_el_ids = unique!(sort!(active_test_el_ids))
+    active_trial_el_ids = unique!(sort!(active_trial_el_ids))
+
+    @assert length(active_test_el_ids) <= length(test_elements)
+    @assert length(active_trial_el_ids) <= length(bsis_elements)
+
+    @assert maximum(active_test_el_ids) <= length(test_elements) "$(maximum(active_test_el_ids)), $(length(test_elements))"
+    @assert maximum(active_trial_el_ids) <= length(bsis_elements) "$(maximum(active_trial_el_ids)), $(length(bsis_elements))"
+
+    for p in active_test_el_ids
+        tcell = test_elements[p]
+        for q in active_trial_el_ids
+            bcell = bsis_elements[q]
+
+            fill!(zlocals[Threads.threadid()], 0)
+            qrule = quadrule(biop, test_shapes, trial_shapes, p, tcell, q, bcell, quadrature_data, quadstrat)
+            momintegrals_test_refines_trial!(zlocals[Threads.threadid()], biop,
+                tfs, p, tcell,
+                bfs, q, bcell,
+                qrule, quadstrat)
             for j in 1 : size(zlocals[Threads.threadid()],2)
                 for i in 1 : size(zlocals[Threads.threadid()],1)
                     for (n,b) in trial_assembly_data[q,j]

--- a/test/test_blockassembler.jl
+++ b/test/test_blockassembler.jl
@@ -1,0 +1,28 @@
+using BEAST
+using CompScienceMeshes
+using LinearAlgebra
+using Test
+
+r = 10.0
+λ = 20 * r
+k = 2 * π / λ
+
+sphere = readmesh(joinpath(dirname(@__FILE__),"assets","sphere5.in"), T=Float64)
+
+D = Maxwell3D.doublelayer(wavenumber=k)
+X = raviartthomas(sphere)
+Y = buffachristiansen(sphere)
+
+A = assemble(D, X, X)
+
+@views blkasm = BEAST.blockassembler(D, X, X)
+
+@views function assembler(Z, tdata, sdata)
+    @views store(v,m,n) = (Z[m,n] += v)
+    blkasm(tdata,sdata,store)
+end
+
+A_blk = zeros(ComplexF64, length(X.fns), length(Y.fns))
+assembler(A_blk, [1:length(X.fns);], [1:length(Y.fns);])
+
+@test norm(A - A_blk) ≈ 0 atol=eps(Float64) 


### PR DESCRIPTION
Recently, the handling of mixed discretization involving both dual and primal functions has been updated in the assembler function.

This commit modifies the blockassembler function to follow this novel handling of the assembler function.