### PR TITLE
fix in computation of restrict for NDRefSpace and assembly of Tensor Identity op

### DIFF
--- a/src/bases/local/ndlocal.jl
+++ b/src/bases/local/ndlocal.jl
@@ -61,7 +61,7 @@ function restrict(ϕ::NDRefSpace{T}, dom1, dom2) where T
 
         for j in 1:K
             # Q[j,i] = dot(y[j][1], m) * l
-            Q[i,j] = dot(y[j][1], t)
+            Q[j,i] = dot(y[j][1], t)
         end
     end
 

--- a/test/test_restrict.jl
+++ b/test/test_restrict.jl
@@ -67,4 +67,18 @@ for T in [Float32, Float64]
         0  1 0
         0 -1 2] // 4
     end
+
+    # Test restriction of Nedelec elements
+    ψ = BEAST.NDRefSpace{T}()
+    Q = restrict(ψ, p, p)
+    if T==Float64
+    @test Q == Matrix(LinearAlgebra.I, 3, 3)
+
+    q = simplex([T.(e0+e1), T.(2*e1), T.(e1+e2)], Val{2})
+    Q = restrict(ψ, p, q)
+    @test Q == [
+        2 -1 0
+        0  1 0
+        0 -1 2] // 4
+    end
 end

--- a/test/test_tensor_identityop.jl
+++ b/test/test_tensor_identityop.jl
@@ -1,0 +1,16 @@
+using Test
+using BEAST
+using CompScienceMeshes
+
+Γ = meshrectangle(1.0, 1.0, 0.5, 3)
+X = raviartthomas(Γ)
+fns = numfunctions(X)
+id = Identity()⊗Identity()
+
+Δt, Nt = 1.01, 10
+δ = timebasisdelta(Δt,Nt)
+h = timebasisc0d1(Δt,Nt)
+
+idop = (id, X⊗δ, X⊗h)
+G = assemble(idop...)
+@test size(G) == (fns, fns, Nt)


### PR DESCRIPTION
1. The restrict for NDRefSpace was computing the transpose, and is fixed.
2. The scalartype deduction during the storage allocation for the tensor operator was based only on operator which results in error if the operator is Identity(). It is modified to deduce the scalartype which is the widest of operator type, trial bases and test bases.
3. Tests for both the modification above are added 