### PR TITLE
Feature/HH3DSauterSchwab

### DIFF
--- a/src/helmholtz3d/hh3dops.jl
+++ b/src/helmholtz3d/hh3dops.jl
@@ -375,7 +375,7 @@ end
 
 function (igd::Integrand{<:HH3DHyperSingularFDBIO})(x,y,f,g)
     α = igd.operator.alpha
-    β = igd.operator.alpha
+    β = igd.operator.beta
     γ = igd.operator.gamma
 
     r = cartesian(x) - cartesian(y)


### PR DESCRIPTION
Compatibility for using Sauter Schwab Quadrature with the Helmholtz3D DoubleLayer and DoubleLayerTransposed was missing so far, the needed functions have been added.
Also, it appeared to me that the use of the Wilton integration rule for the Helmholtz single layer had discrepancies in the terms used for the regular and singular part of the operator, and also the case in which it is used deviated from what I expected (it was only called when the quadstrat is DoubleNumQStrat is used, not for DoubleNumWiltonSauterQStrat). I changed this to fit the name of the quadrature strategies and what is used for the Maxwell operators.