### PR TITLE
Feature Linear Basis functions

### DIFF
--- a/src/BEAST.jl
+++ b/src/BEAST.jl
@@ -214,7 +214,7 @@ include("maxwell/spotential.jl")
 include("maxwell/maxwell.jl")
 include("maxwell/sourcefield.jl")
 
-# Support for the Helmholtz equatio
+# Support for the Helmholtz equation
 include("helmholtz2d/helmholtzop.jl")
 
 include("helmholtz3d/hh3dexc.jl")
@@ -223,6 +223,7 @@ include("helmholtz3d/nitsche.jl")
 include("helmholtz3d/hh3dnear.jl")
 include("helmholtz3d/hh3dfar.jl")
 include("helmholtz3d/hh3d_sauterschwabqr.jl")
+include("helmholtz3d/wiltonints.jl")
 
 #suport for Volume Integral equation
 include("volumeintegral/vie.jl")

--- a/src/helmholtz3d/hh3dops.jl
+++ b/src/helmholtz3d/hh3dops.jl
@@ -153,9 +153,9 @@ end
 
 
 
-function quadrule(op::HH3DSingleLayerFDBIO,
-        test_refspace::LagrangeRefSpace{T,0} where T,
-        trial_refspace::LagrangeRefSpace{T,0} where T,
+function quadrule(op::Helmholtz3DOp,
+        test_refspace::LagrangeRefSpace,
+        trial_refspace::LagrangeRefSpace,
         i, test_element, j, trial_element, qd,
         qs::DoubleNumWiltonSauterQStrat)
 
@@ -205,9 +205,9 @@ end
 regularpart(op::HH3DHyperSingularFDBIO) = HH3DHyperSingularReg(op.alpha, op.beta, op.gamma)
 singularpart(op::HH3DHyperSingularFDBIO) = HH3DHyperSingularSng(op.alpha, op.beta, op.gamma)
 
-function quadrule(op::HH3DHyperSingularFDBIO,
-    test_refspace::LagrangeRefSpace{T,1} where T,
-    trial_refspace::LagrangeRefSpace{T,1} where T,
+#= function quadrule(op::HH3DHyperSingularFDBIO,
+    test_refspace::LagrangeRefSpace,
+    trial_refspace::LagrangeRefSpace,
     i, test_element, j, trial_element, qd,
     qs::DoubleNumWiltonSauterQStrat)
 
@@ -221,19 +221,21 @@ function quadrule(op::HH3DHyperSingularFDBIO,
     hits == 2 && return SauterSchwabQuadrature.CommonEdge(qd.gausslegendre[2])
     hits == 1 && return SauterSchwabQuadrature.CommonVertex(qd.gausslegendre[1])
 
-    # test_quadpoints  = qd.test_qp
-    # trial_quadpoints = qd.bsis_qp
-
-    # hits != 0 && return WiltonSERule(
-    #     test_quadpoints[1,i],
-    #     DoubleQuadRule(
-    #         test_quadpoints[1,i],
-    #         trial_quadpoints[1,j]))
+    test_quadpoints  = qd.test_qp
+    trial_quadpoints = qd.bsis_qp
+    h2 = volume(trial_element)
+    xtol2 = 0.2 * 0.2
+    k2 = abs2(op.gamma)
+    max(dmin2*k2, dmin2/16h2) < xtol2 && return WiltonSERule(
+        test_quadpoints[1,i],
+        DoubleQuadRule(
+            test_quadpoints[1,i],
+            trial_quadpoints[1,j]))
 
     return DoubleQuadRule(
         qd.test_qp[1,i],
         qd.bsis_qp[1,j])
-end
+end =#
 
 
 function quadrule(op::HH3DHyperSingularFDBIO,
@@ -310,7 +312,7 @@ function quadrule(op::Helmholtz3DOp,
         quadrature_data[2][1,j])
 end
 
-function quadrule(op::HH3DDoubleLayerTransposedFDBIO,
+#= function quadrule(op::HH3DDoubleLayerTransposedFDBIO,
     test_refspace::LagrangeRefSpace{T,1} where T,
     trial_refspace::LagrangeRefSpace{T,0} where T,
     i, test_element, j, trial_element, quadrature_data,
@@ -334,7 +336,7 @@ function quadrule(op::HH3DDoubleLayerTransposedFDBIO,
     trial_quadpoints = quadrature_data[2]
     test_quadpoints  = quadrature_data.test_qp
     trial_quadpoints = quadrature_data.bsis_qp
-#=     h2 = volume(trial_element)
+    h2 = volume(trial_element)
     xtol2 = 0.2 * 0.2
     k2 = abs2(op.gamma)
 
@@ -342,13 +344,14 @@ function quadrule(op::HH3DDoubleLayerTransposedFDBIO,
         test_quadpoints[1,i],
         DoubleQuadRule(
             test_quadpoints[1,i],
-            trial_quadpoints[1,j])) =#
+            trial_quadpoints[1,j]))
+
     return DoubleQuadRule(
         quadrature_data[1][1,i],
         quadrature_data[2][1,j])
-end
+end =#
 
-function quadrule(op::HH3DDoubleLayerFDBIO,
+#= function quadrule(op::HH3DDoubleLayerFDBIO,
     test_refspace::LagrangeRefSpace{T,0} where T,
     trial_refspace::LagrangeRefSpace{T,1} where T,
     i, test_element, j, trial_element, quadrature_data,
@@ -384,7 +387,7 @@ function quadrule(op::HH3DDoubleLayerFDBIO,
     return DoubleQuadRule(
         quadrature_data[1][1,i],
         quadrature_data[2][1,j])
-end
+end =#
 
 
 function quadrule(op::Helmholtz3DOp,

--- a/src/helmholtz3d/wiltonints.jl
+++ b/src/helmholtz3d/wiltonints.jl
@@ -1,0 +1,182 @@
+# single layer
+function (igd::Integrand{<:HH3DSingleLayerReg})(x,y,f,g)
+    α = igd.operator.alpha
+    γ = igd.operator.gamma
+
+    r = cartesian(x) - cartesian(y)
+    R = norm(r)
+    iR = 1 / R
+    green = (expm1(-γ*R) #= + γ*R =# - 0.5*γ^2*R^2) / (4pi*R)
+    αG = α * green
+
+    _integrands(f,g) do fi, gi
+        dot(gi.value, αG*fi.value)
+    end
+end
+
+function innerintegrals!(op::HH3DSingleLayerSng, test_neighborhood,
+    test_refspace::LagrangeRefSpace{T,0} where {T},
+    trial_refspace::LagrangeRefSpace{T,0} where {T},
+    test_elements, trial_element, zlocal, quadrature_rule::WiltonSERule, dx)
+
+γ = op.gamma
+α = op.alpha
+
+s1, s2, s3 = trial_element.vertices
+
+x = cartesian(test_neighborhood)
+n = normalize((s1-s3)×(s2-s3))
+ρ = x - dot(x - s1, n) * n
+
+scal, vec = WiltonInts84.wiltonints(s1, s2, s3, x, Val{1})
+∫G = (scal[2]#=  - γ*scal[3] =# + 0.5*γ^2*scal[4]) / (4π)
+
+zlocal[1,1] += α * ∫G * dx
+return nothing
+end
+
+
+
+# double layer transposed
+function (igd::Integrand{<:HH3DDoubleLayerTransposedReg})(x,y,f,g)
+    γ = igd.operator.gamma
+    
+    r = cartesian(x) - cartesian(y)
+    R = norm(r)
+    iR = 1/R
+    γR = γ*R
+    expo = exp(-γR)
+
+    gradgreen = ( -(γR + 1)*expo + (1 - 0.5*γR^2) ) * (i4pi*iR^3) * r
+
+    n = normal(x)
+    fvalue = getvalue(f)
+    gvalue = getvalue(g)
+
+    return _krondot(fvalue,gvalue) * dot(n, gradgreen)
+end
+
+function innerintegrals!(op::HH3DDoubleLayerTransposedSng, test_neighborhood,
+    test_refspace::LagrangeRefSpace{T,1,3,3} where {T},
+    trial_refspace::LagrangeRefSpace{T,0,3,1} where {T},
+    test_elements, trial_element, zlocal, quadrature_rule::WiltonSERule, dx)
+    γ = op.gamma
+    α = op.alpha
+
+    s1, s2, s3 = trial_element.vertices
+    t1, t2, t3 = test_elements.vertices
+    x = cartesian(test_neighborhood)
+    n = normalize((t1-t3)×(t2-t3))
+    ρ = x - dot(x - s1, n) * n
+
+    scal, vec, grad = WiltonInts84.wiltonints(s1, s2, s3, x, Val{1})
+
+    ∫∇G = -(grad[1]+0.5*γ^2*grad[3])/(4π)
+    ∫n∇G = dot(n,∫∇G)
+    Atot = 1/2*norm(cross(t3-t1,t3-t2))
+    for i in 1:numfunctions(test_refspace)
+        Ai = 1/2*norm(cross(test_elements.vertices[mod1(i-1,3)]-x,test_elements.vertices[mod1(i+1,3)]-x))
+        g = Ai/Atot
+        for j in 1:numfunctions(trial_refspace)
+            zlocal[i,j] += α * ∫n∇G * g * dx
+        end
+    end
+
+    return nothing
+end
+
+# double layer
+function (igd::Integrand{<:HH3DDoubleLayerReg})(x,y,f,g)
+    γ = igd.operator.gamma
+
+    r = cartesian(x) - cartesian(y)
+    R = norm(r)
+    iR = 1/R
+    γR = γ*R
+    expo = exp(-γR)
+
+    gradgreen = ( -(γR + 1)*expo + (1 - 0.5*γR^2) ) * (i4pi*iR^3) * r
+
+    n = normal(y)
+    fvalue = getvalue(f)
+    gvalue = getvalue(g)
+
+    return _krondot(fvalue,gvalue) * dot(n, -gradgreen)
+
+end
+
+function innerintegrals!(op::HH3DDoubleLayerSng, p,
+    g::LagrangeRefSpace{T,0} where {T},
+    f::LagrangeRefSpace{T,1} where {T},
+    t, s, z, quadrature_rule::WiltonSERule, dx)
+    γ = op.gamma
+    α = op.alpha
+
+    s1, s2, s3 = s.vertices
+
+    x = cartesian(p)
+    n = normalize((s1-s3)×(s2-s3))
+    ρ = x - dot(x - s1, n) * n
+
+    _, _, _, grad = WiltonInts84.higherorder(s1,s2,s3,x,3)
+
+    ∫∇G = (-grad[1] - 0.5*γ^2*grad[2]) / (4π)
+
+  
+for i in 1:numfunctions(g)
+    for j in 1:numfunctions(f)     
+       z[i,j] += α * dot(n,∫∇G[j]) * dx
+    end
+end
+
+    return nothing
+end
+
+
+function (igd::Integrand{<:HH3DHyperSingularReg})(x,y,f,g)
+    α = igd.operator.alpha
+    β = igd.operator.beta
+    γ = igd.operator.gamma
+
+    r = cartesian(x) - cartesian(y)
+    R = norm(r)
+    iR = 1 / R
+    green = (expm1(-γ*R) - 0.5*γ^2*R^2) / (4pi*R)
+    nx = normal(x)
+    ny = normal(y)
+
+    _integrands(f,g) do fi, gi
+        α*dot(nx,ny)*gi.value*fi.value*green + β*dot(gi.curl,fi.curl)*green
+    end
+end
+
+function innerintegrals!(op::HH3DHyperSingularSng, p,
+    g::LagrangeRefSpace{T,1} where {T},
+    f::LagrangeRefSpace{T,1} where {T},
+    t, s, z, quadrature_rule::WiltonSERule, dx)
+    α = op.alpha
+    β = op.beta
+    γ = op.gamma
+    s1, s2, s3 = s.vertices
+    t1, t2, t3 = t.vertices
+    x = cartesian(p)
+    nx = normalize((s1-s3)×(s2-s3))
+    ny = normalize((t1-t3)×(t2-t3))
+
+    ∫Rⁿ, ∫RⁿN = WiltonInts84.higherorder(s1,s2,s3,x,3)
+    greenconst = (∫Rⁿ[2] + 0.5*γ^2*∫Rⁿ[3]) / (4π)
+    greenlinear = (∫RⁿN[2] + 0.5*γ^2*∫RⁿN[3] ) / (4π)
+
+    jt = volume(t) * factorial(dimension(t))
+    js = volume(s) * factorial(dimension(s))
+    curlt = [(t3-t2)/jt,(t1-t3)/jt,(t2-t1)/jt]
+    curls = [(s3-s2)/js,(s1-s3)/js,(s2-s1)/js]
+    Atot = 1/2*norm(cross(t3-t1,t3-t2))
+    for i in 1:numfunctions(g)
+        Ai = 1/2*norm(cross(t.vertices[mod1(i-1,3)]-x,t.vertices[mod1(i+1,3)]-x))
+        g = Ai/Atot
+        for j in 1:numfunctions(f)
+           z[i,j] += β * dot(curlt[i],curls[j])*greenconst*dx + α*dot(nx,ny) * greenlinear[j]*g*dx
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ include("test_dipole.jl")
 
 include("test_wiltonints.jl")
 include("test_sauterschwabints.jl")
+include("test_hh3dints.jl")
 include("test_ss_nested_meshes.jl")
 include("test_nitsche.jl")
 include("test_nitschehh3d.jl")

--- a/test/test_hh3dints.jl
+++ b/test/test_hh3dints.jl
@@ -1,0 +1,379 @@
+using Test
+using LinearAlgebra
+
+using BEAST, CompScienceMeshes, SauterSchwabQuadrature, StaticArrays
+
+T=Float64
+
+
+# operators
+op1 = Helmholtz3D.singlelayer(gamma=T(2.0))
+op2 = Helmholtz3D.doublelayer(gamma=T(2.0))
+op3 = Helmholtz3D.doublelayer_transposed(gamma=T(2.0))
+op4 = Helmholtz3D.hypersingular(gamma=T(2.0))
+## Common face case:
+@testset "Common Face" begin
+  # triangles
+t1 = simplex(
+  T.(@SVector [0.180878, -0.941848, -0.283207]),
+  T.(@SVector [0.0, -0.980785, -0.19509]),
+  T.(@SVector [0.0, -0.92388, -0.382683]))
+
+  lag0 = BEAST.LagrangeRefSpace{T,0,3,1}() # patch basis
+  lag1 = BEAST.LagrangeRefSpace{T,1,3,3}() #pyramid basis
+
+  tqd0 = BEAST.quadpoints(lag0, [t1], (12,)) #test quadrature data
+  tqd1 = BEAST.quadpoints(lag1, [t1], (12,))
+
+  bqd0 = BEAST.quadpoints(lag0, [t1], (13,)) #basis quadrature data
+  bqd1 = BEAST.quadpoints(lag1, [t1], (13,))
+
+  SE_strategy = BEAST.WiltonSERule( #wilton
+    tqd0[1,1],
+    BEAST.DoubleQuadRule(
+    tqd0[1,1],
+    bqd0[1,1],
+    ),
+  )
+
+  SS_strategy = SauterSchwabQuadrature.CommonFace(BEAST._legendre(8,T(0.0),T(1.0))) #sauter
+
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd0[1,1],
+    bqd0[1,1]
+  )
+
+  z_se = [0.0im]
+  z_ss = [0.0im]
+  z_double = [0.0im]
+
+  BEAST.momintegrals!(op1, lag0, lag0, t1, t1, z_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag0, lag0, t1, t1, z_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag0, lag0, t1, t1, z_double, Double_strategy)
+
+  @test z_se ≈ z_ss rtol=1e-5
+  @test z_double ≈ z_ss rtol = 1e-1
+  @test norm(z_se-z_ss) < norm(z_double-z_ss)
+end
+# common vertex case
+@testset "Common vertex" begin
+  t1 = simplex(
+    T.(@SVector [0.180878, -0.941848, -0.283207]),
+    T.(@SVector [0.0, -0.980785, -0.19509]),
+    T.(@SVector [0.0, -0.92388, -0.382683]))
+  t2 = simplex(
+    T.(@SVector [0.373086, -0.881524, -0.289348]),
+    T.(@SVector [0.180878, -0.941848, -0.283207]),
+    T.(@SVector [0.294908, -0.944921, -0.141962]))
+  lag0 = BEAST.LagrangeRefSpace{T,0,3,1}() # patch basis
+  lag1 = BEAST.LagrangeRefSpace{T,1,3,3}() #pyramid basis
+
+  tqd0 = BEAST.quadpoints(lag0, [t1,t2], (12,)) #test quadrature data
+  tqd1 = BEAST.quadpoints(lag1, [t1,t2], (12,))
+
+  bqd0 = BEAST.quadpoints(lag0, [t1,t2], (13,)) #basis quadrature data
+  bqd1 = BEAST.quadpoints(lag1, [t1,t2], (13,))
+  #single layer
+  SE_strategy = BEAST.WiltonSERule(
+    tqd0[1,1],
+    BEAST.DoubleQuadRule(
+    tqd0[1,1],
+    bqd0[1,2]))
+
+  SS_strategy = SauterSchwabQuadrature.CommonVertex(BEAST._legendre(8,T(0.0),T(1.0)))
+
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd0[1,1],
+    bqd0[1,2]
+  )
+  z_cv_se = zeros(3,1)
+  z_cv_ss = zeros(3,1)
+  z_cv_double = zeros(3,1)
+
+  BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_ss rtol=1e-4
+  #@test norm(z_cv_ss-z_cv_se)/norm(z_cv_ss) < norm(z_cv_ss-z_cv_double)/norm(z_cv_ss)
+  #double layer
+  SE_strategy = BEAST.WiltonSERule(
+    tqd0[1,1],
+    BEAST.DoubleQuadRule(
+    tqd0[1,1],
+    bqd1[1,2]))
+
+  SS_strategy = SauterSchwabQuadrature.CommonVertex(BEAST._legendre(8,T(0.0),T(1.0)))
+
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd0[1,1],
+    bqd1[1,2]
+  )
+  z_cv_se = zeros(1,3)
+  z_cv_ss = zeros(1,3)
+  z_cv_double = zeros(1,3)
+
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_ss rtol=1e-4
+  @test norm(z_cv_ss-z_cv_se)/norm(z_cv_ss) < norm(z_cv_ss-z_cv_double)/norm(z_cv_ss)
+
+  #double layer transposed
+  SE_strategy = BEAST.WiltonSERule(
+    tqd1[1,1],
+    BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd0[1,2]))
+
+  SS_strategy = SauterSchwabQuadrature.CommonVertex(BEAST._legendre(8,T(0.0),T(1.0)))
+
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd1[1,1],
+    bqd0[1,2]
+  )
+  z_cv_se = zeros(3,1)
+  z_cv_ss = zeros(3,1)
+  z_cv_double = zeros(3,1)
+
+  BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_ss rtol=1e-4
+  @test norm(z_cv_ss-z_cv_se)/norm(z_cv_ss) < norm(z_cv_ss-z_cv_double)/norm(z_cv_ss)
+
+  #hypersingular
+  SE_strategy = BEAST.WiltonSERule(
+    tqd1[1,1],
+    BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd1[1,2]))
+
+  SS_strategy = SauterSchwabQuadrature.CommonVertex(BEAST._legendre(8,T(0.0),T(1.0)))
+
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd1[1,1],
+    bqd1[1,2]
+  )
+  z_cv_se = zeros(3,3)
+  z_cv_ss = zeros(3,3)
+  z_cv_double = zeros(3,3)
+
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_ss rtol=1e-4
+  #@test norm(z_cv_ss-z_cv_se)/norm(z_cv_ss) < norm(z_cv_ss-z_cv_double)/norm(z_cv_ss)
+
+end
+
+@testset "Common edge" begin
+  # common edge
+  t1 = simplex(
+      T.(@SVector [0.180878, -0.941848, -0.283207]),
+      T.(@SVector [0.0, -0.980785, -0.19509]),
+      T.(@SVector [0.0, -0.92388, -0.382683])
+      )
+  t2 = simplex(
+      T.(@SVector [0.180878, -0.941848, -0.283207]),
+      T.(@SVector [0.158174, -0.881178, -0.44554]),
+      T.(@SVector [0.0, -0.92388, -0.382683])
+      )
+
+  lag0 = BEAST.LagrangeRefSpace{T,0,3,1}() # patch basis
+  lag1 = BEAST.LagrangeRefSpace{T,1,3,3}() #pyramid basis
+
+  tqd0 = BEAST.quadpoints(lag0, [t1,t2], (12,)) #test quadrature data
+  tqd1 = BEAST.quadpoints(lag1, [t1,t2], (12,))
+
+  bqd0 = BEAST.quadpoints(lag0, [t1,t2], (13,)) #basis quadrature data
+  bqd1 = BEAST.quadpoints(lag1, [t1,t2], (13,))
+  # singlelayer
+  SE_strategy = BEAST.WiltonSERule(
+    tqd0[1,1],
+    BEAST.DoubleQuadRule(
+    tqd0[1,1],
+    bqd0[1,2]))
+
+  SS_strategy = SauterSchwabQuadrature.CommonEdge(BEAST._legendre(8,T(0.0),T(1.0)))
+
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd0[1,1],
+    bqd0[1,2]
+  )
+  z_ce_se = zeros(3,1)
+  z_ce_ss = zeros(3,1)
+  z_ce_double = zeros(3,1)
+
+  BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_se ≈ z_ce_ss rtol=1e-4
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-3
+  @test norm(z_ce_ss-z_ce_se)/norm(z_ce_ss) < norm(z_ce_ss-z_ce_double)/norm(z_ce_ss)
+
+  # doublelayer
+  SE_strategy = BEAST.WiltonSERule(
+    tqd0[1,1],
+    BEAST.DoubleQuadRule(
+    tqd0[1,1],
+    bqd1[1,2]))
+  SS_strategy = SauterSchwabQuadrature.CommonEdge(BEAST._legendre(8,T(0.0),T(1.0)))
+  Double_strategy = BEAST.DoubleQuadRule(
+    tqd0[1,1],
+    bqd1[1,2])
+  z_ce_se = zeros(1,3)
+  z_ce_ss = zeros(1,3)
+  z_ce_double = zeros(1,3)
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_se ≈ z_ce_ss rtol = 1e-4
+  @test z_ce_ss ≈ z_ce_double rtol = 1e-1
+  @test norm(z_ce_ss-z_ce_se)/norm(z_ce_ss) < norm(z_ce_ss-z_ce_double)/norm(z_ce_ss)
+
+  # doublelayer transposed
+  SE_strategy = BEAST.WiltonSERule(
+      tqd1[1,1],
+      BEAST.DoubleQuadRule(
+          tqd1[1,1],
+          bqd0[1,2]))
+  SS_strategy = SauterSchwabQuadrature.CommonEdge(BEAST._legendre(12,T(0.0),T(1.0)))
+  Double_strategy = BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd0[1,2])
+  z_ce_se = zeros(3,1)
+  z_ce_ss = zeros(3,1)
+  z_ce_double = zeros(3,1)
+
+  BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_se ≈ z_ce_ss rtol=1e-2
+  @test z_ce_ss ≈ z_ce_double rtol = 1e-1
+  @test norm(z_ce_ss-z_ce_se)/norm(z_ce_ss) < norm(z_ce_ss-z_ce_double)/norm(z_ce_ss)
+
+  # hypersingular
+
+  SE_strategy = BEAST.WiltonSERule(
+      tqd1[1,1],
+      BEAST.DoubleQuadRule(
+          tqd1[1,1],
+          bqd1[1,2]))
+  SS_strategy = SauterSchwabQuadrature.CommonEdge(BEAST._legendre(12,T(0.0),T(1.0)))
+  Double_strategy = BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd1[1,2])
+
+  z_ce_se = zeros(3,3)
+  z_ce_ss = zeros(3,3)
+  z_ce_double = zeros(3,3)
+
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_double, Double_strategy)
+  @test z_ce_se ≈ z_ce_ss rtol = 1e-5
+  @test z_ce_double ≈ z_ce_double rtol = 1e-5
+  @test norm(z_ce_se-z_ce_ss) < norm(z_ce_double-z_ce_ss)
+
+end
+
+@testset "Seperated triangles" begin
+  t1 = simplex(
+      T.(@SVector [0.180878, -0.941848, -0.283207]),
+      T.(@SVector [0.0, -0.980785, -0.19509]),
+      T.(@SVector [0.0, -0.92388, -0.382683]))
+  t2 = simplex(
+      T.(@SVector [0.373086, -0.881524, -1.289348]),
+      T.(@SVector [0.180878, -0.941848, -1.283207]),
+      T.(@SVector [0.294908, -0.944921, -1.141962]))
+
+  lag0 = BEAST.LagrangeRefSpace{T,0,3,1}() # patch basis
+  lag1 = BEAST.LagrangeRefSpace{T,1,3,3}() #pyramid basis
+  
+  tqd0 = BEAST.quadpoints(lag0, [t1,t2], (12,)) #test quadrature data
+  tqd1 = BEAST.quadpoints(lag1, [t1,t2], (12,))
+  
+  bqd0 = BEAST.quadpoints(lag0, [t1,t2], (13,)) #basis quadrature data
+  bqd1 = BEAST.quadpoints(lag1, [t1,t2], (13,))
+  # singlelayer
+  SE_strategy = BEAST.WiltonSERule(
+    tqd0[1,1],
+    BEAST.DoubleQuadRule(
+    tqd0[1,1],
+    bqd0[1,2]))
+  
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd0[1,1],
+    bqd0[1,2]
+  )
+  z_ce_se = zeros(3,1)
+  z_ce_double = zeros(3,1)
+  
+  BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_ce_double, Double_strategy)
+  
+  @test z_ce_se ≈ z_ce_double rtol=1e-7
+  
+  # doublelayer
+  SE_strategy = BEAST.WiltonSERule(
+    tqd0[1,1],
+    BEAST.DoubleQuadRule(
+    tqd0[1,1],
+    bqd1[1,2]))
+
+  Double_strategy = BEAST.DoubleQuadRule(
+    tqd0[1,1],
+    bqd1[1,2])
+  z_ce_se = zeros(1,3)
+  z_ce_double = zeros(1,3)
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_double, Double_strategy)
+  
+  @test z_ce_se ≈ z_ce_double rtol = 1e-8
+  
+  # doublelayer transposed
+  SE_strategy = BEAST.WiltonSERule(
+      tqd1[1,1],
+      BEAST.DoubleQuadRule(
+          tqd1[1,1],
+          bqd0[1,2]))
+  Double_strategy = BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd0[1,2])
+  z_ce_se = zeros(3,1)
+  z_ce_double = zeros(3,1)
+  
+  BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_ce_double, Double_strategy)
+  
+  @test z_ce_se ≈ z_ce_double rtol=1e-7
+  
+  # hypersingular
+  SE_strategy = BEAST.WiltonSERule(
+      tqd1[1,1],
+      BEAST.DoubleQuadRule(
+          tqd1[1,1],
+          bqd1[1,2]))
+  Double_strategy = BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd1[1,2])
+  
+  z_ce_se = zeros(3,3)
+  z_ce_double = zeros(3,3)
+  
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_double, Double_strategy)
+  @test z_ce_se ≈ z_ce_double rtol = 1e-7
+
+end

--- a/test/test_hh3dints.jl
+++ b/test/test_hh3dints.jl
@@ -7,10 +7,10 @@ T=Float64
 
 
 # operators
-op1 = Helmholtz3D.singlelayer(gamma=T(2.0))
-op2 = Helmholtz3D.doublelayer(gamma=T(2.0))
-op3 = Helmholtz3D.doublelayer_transposed(gamma=T(2.0))
-op4 = Helmholtz3D.hypersingular(gamma=T(2.0))
+op1 = Helmholtz3D.singlelayer(gamma=T(1.0)im+T(1.0))
+op2 = Helmholtz3D.doublelayer(gamma=T(1.0)im+T(1.0))
+op3 = Helmholtz3D.doublelayer_transposed(gamma=T(1.0)im+T(1.0))
+op4 = Helmholtz3D.hypersingular(gamma=T(1.0)im+T(1.0))
 ## Common face case:
 @testset "Common Face" begin
   # triangles
@@ -22,11 +22,11 @@ t1 = simplex(
   lag0 = BEAST.LagrangeRefSpace{T,0,3,1}() # patch basis
   lag1 = BEAST.LagrangeRefSpace{T,1,3,3}() #pyramid basis
 
-  tqd0 = BEAST.quadpoints(lag0, [t1], (12,)) #test quadrature data
-  tqd1 = BEAST.quadpoints(lag1, [t1], (12,))
+  tqd0 = BEAST.quadpoints(lag0, [t1], (13,)) #test quadrature data
+  tqd1 = BEAST.quadpoints(lag1, [t1], (13,))
 
-  bqd0 = BEAST.quadpoints(lag0, [t1], (13,)) #basis quadrature data
-  bqd1 = BEAST.quadpoints(lag1, [t1], (13,))
+  bqd0 = BEAST.quadpoints(lag0, [t1], (12,)) #basis quadrature data
+  bqd1 = BEAST.quadpoints(lag1, [t1], (12,))
 
   SE_strategy = BEAST.WiltonSERule( #wilton
     tqd0[1,1],
@@ -36,8 +36,8 @@ t1 = simplex(
     ),
   )
 
-  SS_strategy = SauterSchwabQuadrature.CommonFace(BEAST._legendre(8,T(0.0),T(1.0))) #sauter
-
+  SS_strategy = SauterSchwabQuadrature.CommonFace(BEAST._legendre(12,T(0.0),T(1.0))) #sauter
+#single layer with patch-patch
   Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
     tqd0[1,1],
     bqd0[1,1]
@@ -54,8 +54,84 @@ t1 = simplex(
   @test z_se ≈ z_ss rtol=1e-5
   @test z_double ≈ z_ss rtol = 1e-1
   @test norm(z_se-z_ss) < norm(z_double-z_ss)
+
+  #single layer with patch-pyramid
+  SE_strategy = BEAST.WiltonSERule( #wilton
+  tqd1[1,1],
+  BEAST.DoubleQuadRule(
+  tqd1[1,1],
+  bqd0[1,1],
+  ),)
+  Double_strategy = BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd0[1,1],
+    )
+
+  z_se = zeros(complex(T),3,1)
+  z_ss = zeros(complex(T),3,1)
+  z_double = zeros(complex(T),3,1)
+  BEAST.momintegrals!(op1, lag1, lag0, t1, t1, z_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag1, lag0, t1, t1, z_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag1, lag0, t1, t1, z_double, Double_strategy)
+
+  @test z_ss ≈ z_se rtol = 1e-5
+  @test z_ss ≈ z_double rtol = 1e-1
+  @test norm(z_ss-z_se) < norm(z_ss-z_double)
+
+#single layer with pyramid-patch
+  SE_strategy = BEAST.WiltonSERule( #wilton
+  tqd0[1,1],
+  BEAST.DoubleQuadRule(
+  tqd0[1,1],
+  bqd1[1,1],
+  ),)
+  Double_strategy = BEAST.DoubleQuadRule(
+    tqd0[1,1],
+    bqd1[1,1],
+    )
+
+  z_se = zeros(complex(T),1,3)
+  z_ss = zeros(complex(T),1,3)
+  z_double = zeros(complex(T),1,3)
+  BEAST.momintegrals!(op1, lag0, lag1, t1, t1, z_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag0, lag1, t1, t1, z_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag0, lag1, t1, t1, z_double, Double_strategy)
+
+  @test z_ss ≈ z_se rtol = 1e-5
+  @test z_ss ≈ z_double rtol = 1e-1
+  @test norm(z_ss-z_se) < norm(z_ss-z_double)
+
+  #single layer with pyramid pyramid
+  SE_strategy = BEAST.WiltonSERule( #wilton
+  tqd1[1,1],
+  BEAST.DoubleQuadRule(
+  tqd1[1,1],
+  bqd1[1,1],
+  ),)
+  Double_strategy = BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd1[1,1],
+    )
+
+  z_se = zeros(complex(T),3,3)
+  z_ss = zeros(complex(T),3,3)
+  z_double = zeros(complex(T),3,3)
+  BEAST.momintegrals!(op1, lag1, lag1, t1, t1, z_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag1, lag1, t1, t1, z_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag1, lag1, t1, t1, z_double, Double_strategy)
+
+  @test z_ss ≈ z_se rtol = 1e-5
+  @test z_ss ≈ z_double rtol = 1e-1
+  @test norm(z_ss-z_se) < norm(z_ss-z_double)
+
 end
 # common vertex case
+
+# In the common vertex case, for the single layer and hypersingular,
+# the double quadrature apparently is better than the wilton method.
+# It is not clear to me why this is. If someone knows why this happens
+# I would be grateful for an explanation.
+
 @testset "Common vertex" begin
   t1 = simplex(
     T.(@SVector [0.180878, -0.941848, -0.283207]),
@@ -73,7 +149,7 @@ end
 
   bqd0 = BEAST.quadpoints(lag0, [t1,t2], (13,)) #basis quadrature data
   bqd1 = BEAST.quadpoints(lag1, [t1,t2], (13,))
-  #single layer
+#patch patch
   SE_strategy = BEAST.WiltonSERule(
     tqd0[1,1],
     BEAST.DoubleQuadRule(
@@ -86,9 +162,11 @@ end
     tqd0[1,1],
     bqd0[1,2]
   )
-  z_cv_se = zeros(3,1)
-  z_cv_ss = zeros(3,1)
-  z_cv_double = zeros(3,1)
+  #single layer
+
+  z_cv_se = zeros(complex(T),1,1)
+  z_cv_ss = zeros(complex(T),1,1)
+  z_cv_double = zeros(complex(T),1,1)
 
   BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_cv_se, SE_strategy)
   BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_cv_ss, SS_strategy)
@@ -96,33 +174,96 @@ end
 
   @test z_cv_double ≈ z_cv_ss rtol = 1e-4
   @test z_cv_se ≈ z_cv_ss rtol=1e-4
-  #@test norm(z_cv_ss-z_cv_se)/norm(z_cv_ss) < norm(z_cv_ss-z_cv_double)/norm(z_cv_ss)
-  #double layer
-  SE_strategy = BEAST.WiltonSERule(
-    tqd0[1,1],
-    BEAST.DoubleQuadRule(
-    tqd0[1,1],
-    bqd1[1,2]))
+  @test norm(z_cv_ss-z_cv_se)/norm(z_cv_ss) < norm(z_cv_ss-z_cv_double)/norm(z_cv_ss) broken = true
+  #doublelayer
+  z_cv_se = zeros(complex(T),1,1)
+  z_cv_ss = zeros(complex(T),1,1)
+  z_cv_double = zeros(complex(T),1,1)
 
-  SS_strategy = SauterSchwabQuadrature.CommonVertex(BEAST._legendre(8,T(0.0),T(1.0)))
+  BEAST.momintegrals!(op2, lag0, lag0, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag0, lag0, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op2, lag0, lag0, t1, t2, z_cv_double, Double_strategy)
 
-  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
-    tqd0[1,1],
-    bqd1[1,2]
-  )
-  z_cv_se = zeros(1,3)
-  z_cv_ss = zeros(1,3)
-  z_cv_double = zeros(1,3)
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_double rtol=1e-4
+  @test norm(z_cv_ss-z_cv_se) < norm(z_cv_ss-z_cv_double)
 
-  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_cv_se, SE_strategy)
-  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_cv_ss, SS_strategy)
-  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_cv_double, Double_strategy)
+  # doublelayer_transposed
+  z_cv_se = zeros(complex(T),1,1)
+  z_cv_ss = zeros(complex(T),1,1)
+  z_cv_double = zeros(complex(T),1,1)
+
+  BEAST.momintegrals!(op3, lag0, lag0, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op3, lag0, lag0, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op3, lag0, lag0, t1, t2, z_cv_double, Double_strategy)
 
   @test z_cv_double ≈ z_cv_ss rtol = 1e-4
   @test z_cv_se ≈ z_cv_ss rtol=1e-4
-  @test norm(z_cv_ss-z_cv_se)/norm(z_cv_ss) < norm(z_cv_ss-z_cv_double)/norm(z_cv_ss)
+  @test norm(z_cv_ss-z_cv_se) < norm(z_cv_ss-z_cv_double)
 
-  #double layer transposed
+#pyramid pyramid
+  # singlelayer
+  SE_strategy = BEAST.WiltonSERule(
+    tqd1[1,1],
+    BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd1[1,2]))
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd1[1,1],
+    bqd1[1,2]
+  )
+  z_cv_se = zeros(complex(T),3,3)
+  z_cv_ss = zeros(complex(T),3,3)
+  z_cv_double = zeros(complex(T),3,3)
+
+  BEAST.momintegrals!(op1, lag1, lag1, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag1, lag1, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag1, lag1, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_double rtol=1e-4
+  @test norm(z_cv_ss-z_cv_se) < norm(z_cv_ss-z_cv_double) broken = true
+
+  #doublelayer 
+  z_cv_se = zeros(complex(T),3,3)
+  z_cv_ss = zeros(complex(T),3,3)
+  z_cv_double = zeros(complex(T),3,3)
+
+  BEAST.momintegrals!(op2, lag1, lag1, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag1, lag1, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op2, lag1, lag1, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_ss rtol=1e-4
+  @test norm(z_cv_ss-z_cv_se) < norm(z_cv_ss-z_cv_double)
+
+  #doublelayer_transposed
+  z_cv_se = zeros(complex(T),3,3)
+  z_cv_ss = zeros(complex(T),3,3)
+  z_cv_double = zeros(complex(T),3,3)
+
+  BEAST.momintegrals!(op3, lag1, lag1, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op3, lag1, lag1, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op3, lag1, lag1, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-3
+  @test z_cv_double ≈ z_cv_se rtol = 1e-5
+  @test norm(z_cv_ss-z_cv_se) < norm(z_cv_ss-z_cv_double)
+
+  #hypersingular
+  z_cv_se = zeros(complex(T),3,3)
+  z_cv_ss = zeros(complex(T),3,3)
+  z_cv_double = zeros(complex(T),3,3)
+
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_ss rtol=1e-4
+  @test norm(z_cv_ss-z_cv_se) < norm(z_cv_ss-z_cv_double) broken = true
+
+#pyramid test patch basis
   SE_strategy = BEAST.WiltonSERule(
     tqd1[1,1],
     BEAST.DoubleQuadRule(
@@ -135,9 +276,36 @@ end
     tqd1[1,1],
     bqd0[1,2]
   )
-  z_cv_se = zeros(3,1)
-  z_cv_ss = zeros(3,1)
-  z_cv_double = zeros(3,1)
+  #singlelayer
+  z_cv_se = zeros(complex(T),3,1)
+  z_cv_ss = zeros(complex(T),3,1)
+  z_cv_double = zeros(complex(T),3,1)
+
+  BEAST.momintegrals!(op1, lag1, lag0, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag1, lag0, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag1, lag0, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_ss rtol=1e-4
+  @test norm(z_cv_ss-z_cv_se) < norm(z_cv_ss-z_cv_double) broken = true
+
+  #doublelayer
+  z_cv_se = zeros(complex(T),3,1)
+  z_cv_ss = zeros(complex(T),3,1)
+  z_cv_double = zeros(complex(T),3,1)
+
+  BEAST.momintegrals!(op2, lag1, lag0, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag1, lag0, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op2, lag1, lag0, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_ss rtol=1e-4
+  @test norm(z_cv_ss-z_cv_se)/norm(z_cv_ss) < norm(z_cv_ss-z_cv_double)/norm(z_cv_ss)
+  #doublelayer_transposed
+
+  z_cv_se = zeros(complex(T),3,1)
+  z_cv_ss = zeros(complex(T),3,1)
+  z_cv_double = zeros(complex(T),3,1)
 
   BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_cv_se, SE_strategy)
   BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_cv_ss, SS_strategy)
@@ -145,32 +313,59 @@ end
 
   @test z_cv_double ≈ z_cv_ss rtol = 1e-4
   @test z_cv_se ≈ z_cv_ss rtol=1e-4
-  @test norm(z_cv_ss-z_cv_se)/norm(z_cv_ss) < norm(z_cv_ss-z_cv_double)/norm(z_cv_ss)
+  @test norm(z_cv_ss-z_cv_se) < norm(z_cv_ss-z_cv_double)
 
-  #hypersingular
+  #pyramid basis patch test
   SE_strategy = BEAST.WiltonSERule(
-    tqd1[1,1],
+    tqd0[1,1],
     BEAST.DoubleQuadRule(
-    tqd1[1,1],
+    tqd0[1,1],
     bqd1[1,2]))
 
   SS_strategy = SauterSchwabQuadrature.CommonVertex(BEAST._legendre(8,T(0.0),T(1.0)))
 
   Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
-    tqd1[1,1],
+    tqd0[1,1],
     bqd1[1,2]
   )
-  z_cv_se = zeros(3,3)
-  z_cv_ss = zeros(3,3)
-  z_cv_double = zeros(3,3)
+  #singlelayer
+  z_cv_se = zeros(complex(T),1,3)
+  z_cv_ss = zeros(complex(T),1,3)
+  z_cv_double = zeros(complex(T),1,3)
 
-  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_cv_se, SE_strategy)
-  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_cv_ss, SS_strategy)
-  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_cv_double, Double_strategy)
+  BEAST.momintegrals!(op1, lag0, lag1, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag0, lag1, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag0, lag1, t1, t2, z_cv_double, Double_strategy)
 
   @test z_cv_double ≈ z_cv_ss rtol = 1e-4
   @test z_cv_se ≈ z_cv_ss rtol=1e-4
-  #@test norm(z_cv_ss-z_cv_se)/norm(z_cv_ss) < norm(z_cv_ss-z_cv_double)/norm(z_cv_ss)
+  @test norm(z_cv_ss-z_cv_se) < norm(z_cv_ss-z_cv_double) broken = true
+
+  #double layer
+  z_cv_se = zeros(complex(T),1,3)
+  z_cv_ss = zeros(complex(T),1,3)
+  z_cv_double = zeros(complex(T),1,3)
+
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_ss rtol=1e-4
+  @test norm(z_cv_ss-z_cv_se) < norm(z_cv_ss-z_cv_double)
+
+  #double layer transposed
+  z_cv_se = zeros(complex(T),1,3)
+  z_cv_ss = zeros(complex(T),1,3)
+  z_cv_double = zeros(complex(T),1,3)
+
+  BEAST.momintegrals!(op3, lag0, lag1, t1, t2, z_cv_se, SE_strategy)
+  BEAST.momintegrals!(op3, lag0, lag1, t1, t2, z_cv_ss, SS_strategy)
+  BEAST.momintegrals!(op3, lag0, lag1, t1, t2, z_cv_double, Double_strategy)
+
+  @test z_cv_double ≈ z_cv_ss rtol = 1e-4
+  @test z_cv_se ≈ z_cv_ss rtol=1e-4
+  @test norm(z_cv_ss-z_cv_se) < norm(z_cv_ss-z_cv_double)
 
 end
 
@@ -182,8 +377,8 @@ end
       T.(@SVector [0.0, -0.92388, -0.382683])
       )
   t2 = simplex(
-      T.(@SVector [0.180878, -0.941848, -0.283207]),
       T.(@SVector [0.158174, -0.881178, -0.44554]),
+      T.(@SVector [0.180878, -0.941848, -0.283207]),
       T.(@SVector [0.0, -0.92388, -0.382683])
       )
 
@@ -195,7 +390,8 @@ end
 
   bqd0 = BEAST.quadpoints(lag0, [t1,t2], (13,)) #basis quadrature data
   bqd1 = BEAST.quadpoints(lag1, [t1,t2], (13,))
-  # singlelayer
+
+  #patch patch
   SE_strategy = BEAST.WiltonSERule(
     tqd0[1,1],
     BEAST.DoubleQuadRule(
@@ -208,95 +404,223 @@ end
     tqd0[1,1],
     bqd0[1,2]
   )
-  z_ce_se = zeros(3,1)
-  z_ce_ss = zeros(3,1)
-  z_ce_double = zeros(3,1)
+  #single layer
+
+  z_ce_se = zeros(complex(T),1,1)
+  z_ce_ss = zeros(complex(T),1,1)
+  z_ce_double = zeros(complex(T),1,1)
 
   BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_ce_se, SE_strategy)
   BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_ce_ss, SS_strategy)
   BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_ce_double, Double_strategy)
 
-  @test z_ce_se ≈ z_ce_ss rtol=1e-4
   @test z_ce_double ≈ z_ce_ss rtol = 1e-3
-  @test norm(z_ce_ss-z_ce_se)/norm(z_ce_ss) < norm(z_ce_ss-z_ce_double)/norm(z_ce_ss)
+  @test z_ce_se ≈ z_ce_ss rtol=1e-4
+  @test norm(z_ce_ss-z_ce_se) < norm(z_ce_ss-z_ce_double)
 
-  # doublelayer
-  SE_strategy = BEAST.WiltonSERule(
-    tqd0[1,1],
-    BEAST.DoubleQuadRule(
-    tqd0[1,1],
-    bqd1[1,2]))
-  SS_strategy = SauterSchwabQuadrature.CommonEdge(BEAST._legendre(8,T(0.0),T(1.0)))
-  Double_strategy = BEAST.DoubleQuadRule(
-    tqd0[1,1],
-    bqd1[1,2])
-  z_ce_se = zeros(1,3)
-  z_ce_ss = zeros(1,3)
-  z_ce_double = zeros(1,3)
-  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_se, SE_strategy)
-  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_ss, SS_strategy)
-  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_double, Double_strategy)
+  #doublelayer
+  z_ce_se = zeros(complex(T),1,1)
+  z_ce_ss = zeros(complex(T),1,1)
+  z_ce_double = zeros(complex(T),1,1)
 
-  @test z_ce_se ≈ z_ce_ss rtol = 1e-4
+  BEAST.momintegrals!(op2, lag0, lag0, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag0, lag0, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op2, lag0, lag0, t1, t2, z_ce_double, Double_strategy)
+
   @test z_ce_ss ≈ z_ce_double rtol = 1e-1
+  @test z_ce_se ≈ z_ce_ss rtol = 1e-2
+  @test norm(z_ce_ss-z_ce_se) < norm(z_ce_ss-z_ce_double)
+
+  # doublelayer_transposed
+  z_ce_se = zeros(complex(T),1,1)
+  z_ce_ss = zeros(complex(T),1,1)
+  z_ce_double = zeros(complex(T),1,1)
+
+  BEAST.momintegrals!(op3, lag0, lag0, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op3, lag0, lag0, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op3, lag0, lag0, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-1
+  @test z_ce_se ≈ z_ce_ss rtol=1e-2
+  @test norm(z_ce_ss-z_ce_se) < norm(z_ce_ss-z_ce_double)
+
+#pyramid pyramid
+  # singlelayer
+  SE_strategy = BEAST.WiltonSERule(
+    tqd1[1,1],
+    BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd1[1,2]))
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd1[1,1],
+    bqd1[1,2]
+  )
+  z_ce_se = zeros(complex(T),3,3)
+  z_ce_ss = zeros(complex(T),3,3)
+  z_ce_double = zeros(complex(T),3,3)
+
+  BEAST.momintegrals!(op1, lag1, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag1, lag1, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag1, lag1, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-3
+  @test z_ce_se ≈ z_ce_double rtol=1e-3
+  @test norm(z_ce_ss-z_ce_se) < norm(z_ce_ss-z_ce_double)
+
+  #doublelayer 
+  z_ce_se = zeros(complex(T),3,3)
+  z_ce_ss = zeros(complex(T),3,3)
+  z_ce_double = zeros(complex(T),3,3)
+
+  BEAST.momintegrals!(op2, lag1, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag1, lag1, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op2, lag1, lag1, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-1
+  @test z_ce_se ≈ z_ce_ss rtol=1e-4
   @test norm(z_ce_ss-z_ce_se)/norm(z_ce_ss) < norm(z_ce_ss-z_ce_double)/norm(z_ce_ss)
 
-  # doublelayer transposed
+  #doublelayer_transposed
+  z_ce_se = zeros(complex(T),3,3)
+  z_ce_ss = zeros(complex(T),3,3)
+  z_ce_double = zeros(complex(T),3,3)
+
+  BEAST.momintegrals!(op3, lag1, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op3, lag1, lag1, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op3, lag1, lag1, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-1
+  @test z_ce_ss ≈ z_ce_se rtol = 1e-2
+  @test norm(z_ce_ss-z_ce_se) < norm(z_ce_ss-z_ce_double)
+
+  #hypersingular
+  z_ce_se = zeros(complex(T),3,3)
+  z_ce_ss = zeros(complex(T),3,3)
+  z_ce_double = zeros(complex(T),3,3)
+
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-3
+  @test z_ce_se ≈ z_ce_ss rtol=1e-4
+  @test norm(z_ce_ss-z_ce_se) < norm(z_ce_ss-z_ce_double)
+
+#pyramid test patch basis
   SE_strategy = BEAST.WiltonSERule(
-      tqd1[1,1],
-      BEAST.DoubleQuadRule(
-          tqd1[1,1],
-          bqd0[1,2]))
-  SS_strategy = SauterSchwabQuadrature.CommonEdge(BEAST._legendre(12,T(0.0),T(1.0)))
-  Double_strategy = BEAST.DoubleQuadRule(
     tqd1[1,1],
-    bqd0[1,2])
-  z_ce_se = zeros(3,1)
-  z_ce_ss = zeros(3,1)
-  z_ce_double = zeros(3,1)
+    BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd0[1,2]))
+
+  SS_strategy = SauterSchwabQuadrature.CommonEdge(BEAST._legendre(8,T(0.0),T(1.0)))
+
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd1[1,1],
+    bqd0[1,2]
+  )
+  #singlelayer
+  z_ce_se = zeros(complex(T),3,1)
+  z_ce_ss = zeros(complex(T),3,1)
+  z_ce_double = zeros(complex(T),3,1)
+
+  BEAST.momintegrals!(op1, lag1, lag0, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag1, lag0, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag1, lag0, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-3
+  @test z_ce_se ≈ z_ce_ss rtol=1e-4
+  @test norm(z_ce_ss-z_ce_se) < norm(z_ce_ss-z_ce_double)
+  
+  #doublelayer
+  z_ce_se = zeros(complex(T),3,1)
+  z_ce_ss = zeros(complex(T),3,1)
+  z_ce_double = zeros(complex(T),3,1)
+
+  BEAST.momintegrals!(op2, lag1, lag0, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag1, lag0, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op2, lag1, lag0, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-1
+  @test z_ce_se ≈ z_ce_ss rtol=1e-4
+  @test norm(z_ce_ss-z_ce_se)/norm(z_ce_ss) < norm(z_ce_ss-z_ce_double)/norm(z_ce_ss)
+  #doublelayer_transposed
+  
+  z_ce_se = zeros(complex(T),3,1)
+  z_ce_ss = zeros(complex(T),3,1)
+  z_ce_double = zeros(complex(T),3,1)
 
   BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_ce_se, SE_strategy)
   BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_ce_ss, SS_strategy)
   BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_ce_double, Double_strategy)
 
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-1
   @test z_ce_se ≈ z_ce_ss rtol=1e-2
-  @test z_ce_ss ≈ z_ce_double rtol = 1e-1
   @test norm(z_ce_ss-z_ce_se)/norm(z_ce_ss) < norm(z_ce_ss-z_ce_double)/norm(z_ce_ss)
 
-  # hypersingular
-
+  #pyramid basis patch test
   SE_strategy = BEAST.WiltonSERule(
-      tqd1[1,1],
-      BEAST.DoubleQuadRule(
-          tqd1[1,1],
-          bqd1[1,2]))
-  SS_strategy = SauterSchwabQuadrature.CommonEdge(BEAST._legendre(12,T(0.0),T(1.0)))
-  Double_strategy = BEAST.DoubleQuadRule(
-    tqd1[1,1],
-    bqd1[1,2])
+    tqd0[1,1],
+    BEAST.DoubleQuadRule(
+    tqd0[1,1],
+    bqd1[1,2]))
 
-  z_ce_se = zeros(3,3)
-  z_ce_ss = zeros(3,3)
-  z_ce_double = zeros(3,3)
+  SS_strategy = SauterSchwabQuadrature.CommonEdge(BEAST._legendre(8,T(0.0),T(1.0)))
 
-  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_se, SE_strategy)
-  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_ss, SS_strategy)
-  BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_double, Double_strategy)
-  @test z_ce_se ≈ z_ce_ss rtol = 1e-5
-  @test z_ce_double ≈ z_ce_double rtol = 1e-5
-  @test norm(z_ce_se-z_ce_ss) < norm(z_ce_double-z_ce_ss)
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd0[1,1],
+    bqd1[1,2]
+  )
+  #singlelayer
+  z_ce_se = zeros(complex(T),1,3)
+  z_ce_ss = zeros(complex(T),1,3)
+  z_ce_double = zeros(complex(T),1,3)
+
+  BEAST.momintegrals!(op1, lag0, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag0, lag1, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op1, lag0, lag1, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-3
+  @test z_ce_se ≈ z_ce_ss rtol=1e-4
+  @test norm(z_ce_ss-z_ce_se)/norm(z_ce_ss) < norm(z_ce_ss-z_ce_double)/norm(z_ce_ss)
+
+  #double layer
+  z_ce_se = zeros(complex(T),1,3)
+  z_ce_ss = zeros(complex(T),1,3)
+  z_ce_double = zeros(complex(T),1,3)
+
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-1
+  @test z_ce_se ≈ z_ce_ss rtol=1e-4
+  @test norm(z_ce_ss-z_ce_se)/norm(z_ce_ss) < norm(z_ce_ss-z_ce_double)/norm(z_ce_ss)
+
+  #double layer transposed
+  z_ce_se = zeros(complex(T),1,3)
+  z_ce_ss = zeros(complex(T),1,3)
+  z_ce_double = zeros(complex(T),1,3)
+
+  BEAST.momintegrals!(op3, lag0, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op3, lag0, lag1, t1, t2, z_ce_ss, SS_strategy)
+  BEAST.momintegrals!(op3, lag0, lag1, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_double ≈ z_ce_ss rtol = 1e-1
+  @test z_ce_se ≈ z_ce_ss rtol=1e-1
+  @test norm(z_ce_ss-z_ce_se)/norm(z_ce_ss) < norm(z_ce_ss-z_ce_double)/norm(z_ce_ss)
 
 end
 
 @testset "Seperated triangles" begin
   t1 = simplex(
-      T.(@SVector [0.180878, -0.941848, -0.283207]),
       T.(@SVector [0.0, -0.980785, -0.19509]),
+      T.(@SVector [0.180878, -0.941848, -0.283207]),
       T.(@SVector [0.0, -0.92388, -0.382683]))
   t2 = simplex(
-      T.(@SVector [0.373086, -0.881524, -1.289348]),
-      T.(@SVector [0.180878, -0.941848, -1.283207]),
-      T.(@SVector [0.294908, -0.944921, -1.141962]))
+      T.(@SVector [0.0, -0.980785, -0.230102]),
+      T.(@SVector [0.180878, -0.941848, -0.383207]),
+      T.(@SVector [0.0, -0.92388, -0.411962]))
 
   lag0 = BEAST.LagrangeRefSpace{T,0,3,1}() # patch basis
   lag1 = BEAST.LagrangeRefSpace{T,1,3,3}() #pyramid basis
@@ -317,14 +641,50 @@ end
     tqd0[1,1],
     bqd0[1,2]
   )
-  z_ce_se = zeros(3,1)
-  z_ce_double = zeros(3,1)
+  z_ce_se = zeros(complex(T),1,1)
+  z_ce_double = zeros(complex(T),1,1)
   
   BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_ce_se, SE_strategy)
   BEAST.momintegrals!(op1, lag0, lag0, t1, t2, z_ce_double, Double_strategy)
   
-  @test z_ce_se ≈ z_ce_double rtol=1e-7
+  @test z_ce_se ≈ z_ce_double rtol=1e-6
+
+  # calculate a reference value with hcubature to desired accuracy
+  #=using HCubature
+  r(u,v,t) = (1-u)*t[1]+u*((1-v)*t[2]+v*t[3])
+  gamma=1.0+1.0im
+  jac(u,v,t) = u * norm(cross(t[1],t[2])+cross(t[2],t[3])+cross(t[3],t[1]))
+  function outerf(x)
+    r2(x2) = r(x2[1],x2[2],t1) - r(x[1],x[2],t2)
+    innerf(x2) = exp(-gamma*norm(r2(x2)))/(4*pi*norm(r2(x2))) * jac(x2[1],x2[2],t1)
+    hcubature(innerf, (0.0,0.0), (1.0,1.0), rtol = 1e-8)[1] * jac(x[1],x[2],t2)
+  end
+
+  @show refval = hcubature(outerf, (0.0,0.0), (1.0,1.0), rtol = 1e-8)[1] =#
+  refval = 0.00033563892481993545 - 2.22592609372769e-5im # can be calculated with above code
   
+  @test z_ce_se[1] ≈ refval rtol = 1e-7
+  @test z_ce_double[1] ≈ refval rtol = 1e-6
+
+
+  SE_strategy = BEAST.WiltonSERule(
+    tqd1[1,1],
+    BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd1[1,2]))
+
+  Double_strategy = BEAST.DoubleQuadRule( #doublequadstrat
+    tqd1[1,1],
+    bqd1[1,2]
+  )
+  z_ce_se = zeros(complex(T),3,3)
+  z_ce_double = zeros(complex(T),3,3)
+
+  BEAST.momintegrals!(op1, lag1, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op1, lag1, lag1, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_se ≈ z_ce_double rtol=1e-4
+
   # doublelayer
   SE_strategy = BEAST.WiltonSERule(
     tqd0[1,1],
@@ -335,13 +695,28 @@ end
   Double_strategy = BEAST.DoubleQuadRule(
     tqd0[1,1],
     bqd1[1,2])
-  z_ce_se = zeros(1,3)
-  z_ce_double = zeros(1,3)
+  z_ce_se = zeros(complex(T),1,3)
+  z_ce_double = zeros(complex(T),1,3)
   BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_se, SE_strategy)
   BEAST.momintegrals!(op2, lag0, lag1, t1, t2, z_ce_double, Double_strategy)
   
-  @test z_ce_se ≈ z_ce_double rtol = 1e-8
-  
+  @test z_ce_se ≈ z_ce_double rtol = 1e-4
+
+  SE_strategy = BEAST.WiltonSERule(
+    tqd1[1,1],
+    BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd1[1,2]))
+
+  Double_strategy = BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd1[1,2])
+  z_ce_se = zeros(complex(T),3,3)
+  z_ce_double = zeros(complex(T),3,3)
+  BEAST.momintegrals!(op2, lag1, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op2, lag1, lag1, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_se ≈ z_ce_double rtol = 1e-4
   # doublelayer transposed
   SE_strategy = BEAST.WiltonSERule(
       tqd1[1,1],
@@ -351,14 +726,29 @@ end
   Double_strategy = BEAST.DoubleQuadRule(
     tqd1[1,1],
     bqd0[1,2])
-  z_ce_se = zeros(3,1)
-  z_ce_double = zeros(3,1)
-  
+  z_ce_se = zeros(complex(T),3,1)
+  z_ce_double = zeros(complex(T),3,1)
+
   BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_ce_se, SE_strategy)
   BEAST.momintegrals!(op3, lag1, lag0, t1, t2, z_ce_double, Double_strategy)
-  
-  @test z_ce_se ≈ z_ce_double rtol=1e-7
-  
+
+  @test z_ce_se ≈ z_ce_double rtol=1e-4
+
+  SE_strategy = BEAST.WiltonSERule(
+      tqd1[1,1],
+      BEAST.DoubleQuadRule(
+          tqd1[1,1],
+          bqd1[1,2]))
+  Double_strategy = BEAST.DoubleQuadRule(
+    tqd1[1,1],
+    bqd1[1,2])
+  z_ce_se = zeros(complex(T),3,3)
+  z_ce_double = zeros(complex(T),3,3)
+
+  BEAST.momintegrals!(op3, lag1, lag1, t1, t2, z_ce_se, SE_strategy)
+  BEAST.momintegrals!(op3, lag1, lag1, t1, t2, z_ce_double, Double_strategy)
+
+  @test z_ce_se ≈ z_ce_double rtol=1e-4
   # hypersingular
   SE_strategy = BEAST.WiltonSERule(
       tqd1[1,1],
@@ -368,12 +758,12 @@ end
   Double_strategy = BEAST.DoubleQuadRule(
     tqd1[1,1],
     bqd1[1,2])
-  
-  z_ce_se = zeros(3,3)
-  z_ce_double = zeros(3,3)
-  
+
+  z_ce_se = zeros(complex(T),3,3)
+  z_ce_double = zeros(complex(T),3,3)
+
   BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_se, SE_strategy)
   BEAST.momintegrals!(op4, lag1, lag1, t1, t2, z_ce_double, Double_strategy)
-  @test z_ce_se ≈ z_ce_double rtol = 1e-7
+  @test z_ce_se ≈ z_ce_double rtol = 1e-5
 
 end


### PR DESCRIPTION
For Helmholtz problems, there was so missing support for the singular or near singular integrals when linear basis functions are used. 

In this pull request, 
- functions were adapted or added to allow using SauterSchwab quadratures for the common face/edge/vertex case for all four Helmholtz3D operators for the different combinations of patch/pyramid basis functions available,
- for the near singular case, a Wilton/ singularity extraction was implemented, also for the different combinations of patch/pyramid functions.

I tested the functions by comparing the SauterSchwab, Wilton, and DoubleQuad integrals for the common face/edge/vertex cases and making sure they give similar results, also under the assumption that the Wilton strategy should give results closer to the SauterSchwab strategy than the DoubleQuad does. However, there are some cases where where the DoubleQuad performs better, and I am not sure why that is, it's marked in the code as a comment.
For seperated triangles, I also compare to a reference value that was calculated with the HCubature package.

To get the correct signs in all expressions, this relies on pull request #14 in the WiltonInts84 package.
