### PR TITLE
Add unitfunction to create function basis of constant function

### DIFF
--- a/src/BEAST.jl
+++ b/src/BEAST.jl
@@ -27,7 +27,7 @@ export dot
 
 export planewave
 export RefSpace, numfunctions, coordtype, scalartype, assemblydata, geometry, refspace, valuetype
-export lagrangecxd0, lagrangec0d1, duallagrangec0d1
+export lagrangecxd0, lagrangec0d1, duallagrangec0d1, unitfunction
 export duallagrangecxd0
 export lagdimension
 export restrict

--- a/src/bases/lagrange.jl
+++ b/src/bases/lagrange.jl
@@ -48,6 +48,34 @@ function lagrangecxd0(mesh)
   LagrangeBasis{0,-1,NF}(geometry, fns, pos)
 end
 
+"""
+    unitfunction(mesh)
+
+Constructs a constant function with value 1 on `mesh`.
+"""
+function unitfunction(mesh)
+
+    T = coordtype(mesh)
+    geometry = mesh
+
+    # create the local shapes
+    fns = Vector{Vector{Shape{T}}}(undef, 1)
+    pos = Vector{vertextype(mesh)}(undef, 1)
+    fns[1] = [Shape(i, 1, T(1.0)) for (i, cell) in enumerate(mesh)]
+
+    # Arguably, the position is fairly meaningless
+    # in case of a global function. Might be replaced by something
+    # more useful.
+    # For now, we fill it with the average position of the shape functions
+    p = vertextype(mesh)(0.0, 0.0, 0.0)
+    for cell in mesh
+        p += cartesian(center(chart(mesh, cell)))
+    end
+    pos[1] = p ./ numcells(mesh)
+
+    NF = 1
+    LagrangeBasis{0,-1,NF}(geometry, fns, pos)
+end
 
 """
     lagrangec0d1(mesh[, bnd])

--- a/test/test_basis.jl
+++ b/test/test_basis.jl
@@ -79,6 +79,19 @@ for T in [Float32, Float64]
     @test numfunctions(X) == 1
     @test length(X.fns[1]) == 6
 end
+
+## Test unitfunction
+using CompScienceMeshes
+using BEAST
+using Test
+
+for T in [Float32, Float64]
+    m = meshrectangle(T(1.0), T(1.0), T(0.5), 3)
+    X = unitfunction(m)
+
+    @test numfunctions(X) == 1
+end
+
 ## test the scalar trace for Lagrange functions
 using CompScienceMeshes
 using BEAST


### PR DESCRIPTION
In particular, for electrostatic problems it is useful to define an all constant function (typically, per body).

It can be used for the deflection of nullspaces or the formulation of saddlepoint problems (e.g., when we deal with a floating potential boundary condition)