### PR TITLE
Add unitfunction for lagrange pyramid functions

### DIFF
--- a/src/BEAST.jl
+++ b/src/BEAST.jl
@@ -27,7 +27,7 @@ export dot
 
 export planewave
 export RefSpace, numfunctions, coordtype, scalartype, assemblydata, geometry, refspace, valuetype
-export lagrangecxd0, lagrangec0d1, duallagrangec0d1, unitfunction
+export lagrangecxd0, lagrangec0d1, duallagrangec0d1, unitfunctioncxd0, unitfunctionc0d1
 export duallagrangecxd0
 export lagdimension
 export restrict

--- a/test/test_basis.jl
+++ b/test/test_basis.jl
@@ -87,9 +87,23 @@ using Test
 
 for T in [Float32, Float64]
     m = meshrectangle(T(1.0), T(1.0), T(0.5), 3)
-    X = unitfunction(m)
+    X = unitfunctioncxd0(m)
 
     @test numfunctions(X) == 1
+    @test length(X.fns[1]) == numcells(m)
+    @test assemble(Identity(), X, X) ≈ [1.0]
+
+    X1 = unitfunctionc0d1(m)
+
+    @test numfunctions(X1) == 1
+    @test length(X1.fns[1]) == 6
+    @test assemble(Identity(), X1, X1) ≈ [0.125]
+
+    X2 = unitfunctionc0d1(m; dirichlet=false)
+
+    @test numfunctions(X2) == 1
+    @test length(X2.fns[1]) == numcells(m) * 3
+    @test assemble(Identity(), X2, X2) ≈ [1.0]
 end
 
 ## test the scalar trace for Lagrange functions


### PR DESCRIPTION
After @sbadrian added the unitfunction, I realised that I also need to assemble the hypersingular operator with this kind of basis function.
To enable assembly of hypersingular operator with unitfunction, a Basis consisting of pyramids instead of patches is necessary. I renamed the previous unitfunction to unitfunctioncxd0, and named the pyramid version unitfunctionc0d1.