### PR TITLE
fixup: return correct scalartype for static operators

### DIFF
--- a/src/maxwell/mwops.jl
+++ b/src/maxwell/mwops.jl
@@ -1,7 +1,7 @@
 abstract type MaxwellOperator3D{T,K} <: IntegralOperator end
 abstract type MaxwellOperator3DReg{T,K} <: MaxwellOperator3D{T,K} end
 
-scalartype(op::MaxwellOperator3D{T,K}) where {T, K <: Nothing} = T
+scalartype(op::MaxwellOperator3D{T,K}) where {T, K <: Val{0}} = T
 scalartype(op::MaxwellOperator3D{T,K}) where {T, K} = promote_type(T, K)
 
 gamma(op::MaxwellOperator3D{T,Val{0}}) where {T} = zero(T)

--- a/test/test_handlers.jl
+++ b/test/test_handlers.jl
@@ -50,6 +50,7 @@ for T in [Float16, Float32, Float64]
     @test operator.alpha === T(1)
     @test operator.beta === T(2)
     @test BEAST.gamma(operator) === T(0)
+    @test scalartype(operator) == T
 
     pwave = Helmholtz3D.planewave(; direction=SVector(T(0), T(0), T(1)))
     @test pwave.direction == SVector(T(0), T(0), T(1))


### PR DESCRIPTION
Due to the change from 'nothing' to 'Val{0}', which is used to denote a static operator (gamma = 0), this fixup is necessary to correctly compute the scalartype (currently, for static operators it returns 'Any').