### PR TITLE
Use AbstractMatrix in LU.

### DIFF
--- a/examples/hello.jl
+++ b/examples/hello.jl
@@ -1,2 +1,0 @@
-println()
-println("t")


### PR DESCRIPTION
Using AbstractMatrix in the LU wrapper to avoid converting sparse matrices into dense matrices and using dedicated LU for dense and sparse matrices, respectively.

Removing an empty file from the examples folder.