### PR TITLE
make _BasisTimes, _BasisDot and _BasisCross type stable

### DIFF
--- a/src/bases/composedbasis.jl
+++ b/src/bases/composedbasis.jl
@@ -14,28 +14,31 @@ scalartype(F::FunctionWrapper{T}) where {T} = eltype(T)
 
 abstract type _BasisOperations{T} <: Space{T} end
 
-struct _BasisTimes{T} <: _BasisOperations{T}
-    el1
-    el2
+struct _BasisTimes{T,U,V} <: _BasisOperations{T}
+    el1::U
+    el2::V
 end
+_BasisTimes{T}(el1,el2) where {T} = _BasisTimes{T,typeof(el1),typeof(el2)}(el1,el2)
 _BasisTimes(el1::NormalVector,el2::Space) = _BasisTimes{promote_type(eltype(vertextype(geometry(el2))),scalartype(el2))}(el1,el2)
 _BasisTimes(el2::Space,el1::NormalVector) = _BasisTimes{promote_type(eltype(vertextype(geometry(el2))),scalartype(el2))}(el2,el1)
 _BasisTimes(el1::Space,el2::FunctionWrapper) = _BasisTimes{promote_type(scalartype(el1),scalartype(el2))}(el1,el2)
 _BasisTimes(el1::FunctionWrapper,el2::Space) = _BasisTimes{promote_type(scalartype(el1),scalartype(el2))}(el1,el2)
 
-struct _BasisCross{T} <: _BasisOperations{T}
-    el1
-    el2
+struct _BasisCross{T,U,V} <: _BasisOperations{T}
+    el1::U
+    el2::V
 end
+_BasisCross{T}(el1,el2) where {T} = _BasisCross{T,typeof(el1),typeof(el2)}(el1,el2)
 _BasisCross(el1::NormalVector,el2::Space) = _BasisCross{promote_type(eltype(vertextype(geometry(el2))),scalartype(el2))}(el1,el2)
 _BasisCross(el2::Space,el1::NormalVector) = _BasisCross{promote_type(eltype(vertextype(geometry(el2))),scalartype(el2))}(el2,el1)
 _BasisCross(el1::FunctionWrapper,el2::Space) = _BasisCross{promote_type(scalartype(el1),scalartype(el2))}(el1,el2)
 _BasisCross(el1::Space,el2::FunctionWrapper) = _BasisCross{promote_type(scalartype(el1),scalartype(el2))}(el1,el2)
 
-struct _BasisDot{T} <: _BasisOperations{T}
-    el1
-    el2
+struct _BasisDot{T,U,V} <: _BasisOperations{T}
+    el1::U
+    el2::V
 end
+_BasisDot{T}(el1,el2) where {T} = _BasisDot{T,typeof(el1),typeof(el2)}(el1,el2)
 _BasisDot(el1::NormalVector,el2::Space) = _BasisDot{promote_type(eltype(vertextype(geometry(el2))),scalartype(el2))}(el1,el2)
 _BasisDot(el2::Space,el1::NormalVector) = _BasisDot{promote_type(eltype(vertextype(geometry(el2))),scalartype(el2))}(el2,el1)
 _BasisDot(el1::Space,el2::FunctionWrapper) = _BasisDot{promote_type(scalartype(el1),scalartype(el2))}(el1,el2)


### PR DESCRIPTION
increase performance to assemble for example n.S(n*b)