### PR TITLE
Add static and modified HH2D kernels

### DIFF
--- a/src/helmholtz2d/helmholtz2d.jl
+++ b/src/helmholtz2d/helmholtz2d.jl
@@ -74,7 +74,7 @@ module Helmholtz2D
     )
 
         gamma, wavenumber = Mod.gamma_wavenumber_handler(gamma, wavenumber)
-        Mod.isstatic(gamma) && (gamma = zero(amplitude))
+        Mod.isstatic(gamma) && (gamma = Val(0))
 
         return Mod.HH2DMonopole(position, gamma, amplitude)
     end

--- a/src/helmholtz2d/hh2dexc.jl
+++ b/src/helmholtz2d/hh2dexc.jl
@@ -30,6 +30,13 @@ end
 
 scalartype(f::gradHH2DPlaneWave{P,K,T}) where {P,K,T} = promote_type(eltype(P), K, T)
 
+function grad(m::HH2DPlaneWave)
+    d = m.direction
+    γ = m.gamma
+    a = m.amplitude
+    return gradHH2DPlaneWave(d, γ, a)
+end
+
 struct curlHH2DPlaneWave{P,K,T} <: Functional{T}
     direction::P
     polarization::P
@@ -57,6 +64,37 @@ end
 *(a::Number, m::gradHH2DPlaneWave) = gradHH2DPlaneWave(m.direction, m.gamma, a * m.amplitude)
 *(a::Number, m::curlHH2DPlaneWave) = curlHH2DPlaneWave(m.direction, m.polarization, m.gamma, a * m.amplitude)
 
+"""
+    HH2DLinearPotential
+"""
+struct HH2DLinearPotential{P,T} <: Functional{T}
+    direction::P
+    amplitude::T
+end
+
+function (f::HH2DLinearPotential)(r)
+    d = f.direction
+    a = f.amplitude
+    return a * dot(d, r)
+end
+
+scalartype(f::HH2DLinearPotential{P,T}) where {P,T} = promote_type(eltype(P), T)
+
+struct gradHH2DLinearPotential{P,T} <: Functional{T}
+    direction::P
+    amplitude::T
+end
+
+function (f::gradHH2DLinearPotential)(r)
+    d = f.direction
+    a = f.amplitude
+
+    return a * d
+end
+
+scalartype(f::gradHH2DLinearPotential{P,T}) where {P,T} = promote_type(eltype(P), T)
+
+*(a::Number, m::HH2DLinearPotential) = HH2DLinearPotential(m.direction, a * m.amplitude)
 
 """
     HH2DMonopole
@@ -69,18 +107,48 @@ struct HH2DMonopole{P,K,T}
     amplitude::T
 end
 
+scalartype(x::HH2DMonopole{P,K,T}) where {P, K <: Val{0}, T} = promote_type(eltype(P), T)
 scalartype(x::HH2DMonopole{P,K,T}) where {P,K,T} = promote_type(eltype(P), K, T)
 
 function (f::HH2DMonopole)(r::CompScienceMeshes.MeshPointNM)
     return f(cartesian(r))
 end
 
-function (f::HH2DMonopole)(r)
+# Laplace
+function (f::HH2DMonopole{P,K,T})(r) where {P, K <: Val{0}, T}
     γ = f.gamma
     p = f.position
     a = f.amplitude
+    vecR = r - p
+    R = norm(vecR)
 
-    return a / (4 * im) * hankelh2(0, -im*γ * norm(r - p))
+    green = -a/(2π) * log(R)
+    return green
+end
+
+# Modified Helmholtz 2D
+function (f::HH2DMonopole{P,K,T})(r) where {P, K <: Real, T}
+    γ = f.gamma
+    p = f.position
+    a = f.amplitude
+    vecR = r - p
+    R = norm(vecR)
+
+    green = a/(2π) * besselk(0, γ * R)
+    return green
+end
+
+# Helmholtz 2D
+function (f::HH2DMonopole{P,K,T})(r) where {P, K <: Complex, T}
+    γ = f.gamma
+    p = f.position
+    a = f.amplitude
+    vecR = r - p
+    R = norm(vecR)
+    k = -im*γ
+
+    green = a/(4*im) * hankelh2(0, k * R)
+    return green
 end
 
 struct curlHH2DMonopole{P,K,T}
@@ -91,14 +159,44 @@ end
 
 scalartype(x::curlHH2DMonopole{P,K,T}) where {P,K,T} = promote_type(eltype(P), K, T)
 
-function (f::curlHH2DMonopole)(r)
-    a = f.amplitude
+# Laplace
+function (f::curlHH2DMonopole{P,K,T})(r) where {P, K <: Val{0}, T}
     γ = f.gamma
     p = f.position
-    vecR = r-p
+    a = f.amplitude
+    vecR = r - p
     R = norm(vecR)
 
-    return a / (4 * im) * 1/R * (-im*γ) * (-hankelh2(1,(-im*γ*R))) * (SVector(-vecR[2],vecR[1]))
+    green_deriv = -a/(2*π) * (1/R^2)
+    curl = green_deriv * (SVector(-vecR[2], vecR[1]))
+    return curl
+end
+
+# Modified Helmholtz 2D
+function (f::curlHH2DMonopole{P,K,T})(r) where {P, K <: Real, T}
+    γ = f.gamma
+    p = f.position
+    a = f.amplitude
+    vecR = r - p
+    R = norm(vecR)
+
+    green_deriv = -a/(2*π) * (γ / R) * (besselk(1, γ * R))
+    curl = green_deriv * (SVector(-vecR[2], vecR[1]))
+    return curl
+end
+
+# Helmholtz 2D
+function (f::curlHH2DMonopole{P,K,T})(r) where {P, K <: Complex, T}
+    γ = f.gamma
+    p = f.position
+    a = f.amplitude
+    vecR = r - p
+    R = norm(vecR)
+    k = -im*γ
+
+    green_deriv = -a/(4*im) * (k / R) * (hankelh2(1, k * R))
+    curl = green_deriv * (SVector(-vecR[2], vecR[1]))
+    return curl
 end
 
 function (f::curlHH2DMonopole)(mp::CompScienceMeshes.MeshPointNM)
@@ -119,14 +217,44 @@ end
 
 scalartype(x::gradHH2DMonopole{P,K,T}) where {P,K,T} = promote_type(eltype(P), K, T)
 
-function (f::gradHH2DMonopole)(r)
-    a = f.amplitude
+# Laplace
+function (f::gradHH2DMonopole{P,K,T})(r) where {P, K <: Val{0}, T}
     γ = f.gamma
     p = f.position
+    a = f.amplitude
     vecR = r - p
     R = norm(vecR)
 
-    return a / (4 * im) * -hankelh2(1, -im*γ * R) * (-im*γ) * vecR / R
+    green_deriv = -a/(2*π) * (1/R^2)
+    grad = green_deriv * vecR
+    return grad
+end
+
+# Modified Helmholtz 2D
+function (f::gradHH2DMonopole{P,K,T})(r) where {P, K <: Real, T}
+    γ = f.gamma
+    p = f.position
+    a = f.amplitude
+    vecR = r - p
+    R = norm(vecR)
+
+    green_deriv = -a/(2*π) * (γ / R) * (besselk(1, γ * R))
+    grad = green_deriv * vecR
+    return grad
+end
+
+# Helmholtz 2D
+function (f::gradHH2DMonopole{P,K,T})(r) where {P, K <: Complex, T}
+    γ = f.gamma
+    p = f.position
+    a = f.amplitude
+    vecR = r - p
+    R = norm(vecR)
+    k = -im*γ
+
+    green_deriv = -a/(4*im) * (k / R) * (hankelh2(1, k * R))
+    grad = green_deriv * vecR
+    return grad
 end
 
 function grad(m::HH2DMonopole)

--- a/src/helmholtz2d/hh2dnear.jl
+++ b/src/helmholtz2d/hh2dnear.jl
@@ -1,4 +1,3 @@
-
 struct HH2DSingleLayerNear{T, K}
     alpha::T
     gamma::K
@@ -10,7 +9,7 @@ struct HH2DSingleLayerNear{T, K}
 
     function HH2DSingleLayerNear(op::HH2DSingleLayerFDBIO)
         return HH2DSingleLayerNear(op.alpha, op.gamma)
-    end 
+    end
 end
 
 struct HH2DDoubleLayerNear{T, K}
@@ -56,11 +55,12 @@ struct HH2DHyperSingularNear{T, K}
     end
 end
 
-
-HH2DNear = Union{HH2DSingleLayerNear, HH2DDoubleLayerNear, HH2DDoubleLayerTransposedNear, HH2DHyperSingularNear}
-defaultquadstrat(op::HH2DNear, basis) = SingleNumQStrat(20)
-quaddata(op::HH2DNear,rs,els,qs::SingleNumQStrat) = quadpoints(rs,els,(qs.quad_rule,))
-quadrule(op::HH2DNear,refspace,p,y,q,el,qdata,qs::SingleNumQStrat) = qdata[1,q]
+HH2DNear{T, K} = Union{
+    HH2DSingleLayerNear{T, K},
+    HH2DDoubleLayerNear{T, K},
+    HH2DDoubleLayerTransposedNear{T, K},
+    HH2DHyperSingularNear{T, K}
+} where {T, K}
 
 # TODO: This function is useful for changing the gradient to a curl
 # However, it is a case of type piracy.
@@ -76,88 +76,130 @@ end
     return SVector{2,T2}( v[2], -v[1])
 end
 
+mutable struct KernelValsHH2DNear{K1,K2,F}
+    gamma::K1
+    vect::SVector{2,F}
+    dist::F
+    green::K2
+    gradgreen::SVector{2,K2}
+end
 # WARNING: Matching the HH3D we use x for the sources
 # TODO: Discuss if we change this?
-function kernelvals(op::HH2DNear,y,p)
+
+# Kernel values for 2D Laplace BIE operators
+function kernelvals(op::HH2DNear{T, K}, x, y) where {T, K <: Val{0}}
+
+    yc = cartesian(y)
+    xc = cartesian(x)
+    r = xc - yc
+    R = norm(r)
+
+    #Logarithmic singularity of Hankel function: Gk = -1/(2π) * log(kR)
+    green = -1/(2π) * log(R)
+    gradgreen = -1/(2π) * (1/R) * (r/R)
+
+    return KernelValsHH2DNear(nothing, r, R, green, gradgreen)
+end
+
+# Kernel values for 2D Helmholtz equation BIE operators
+function kernelvals(op::HH2DNear{T, K}, x, y) where {T, K <: Real}
+    γ = op.gamma
+
+    yc = cartesian(y)
+    xc = cartesian(x)
+    r = xc - yc
+    R = norm(r)
+
+    green = 1/(2π) * besselk(0, γ * R)
+    gradgreen = -γ/(2π) * besselk(1, γ * R) * (r/R)
+
+    return KernelValsHH2DNear(γ, r, R, green, gradgreen)
+end
+
+# Kernel values for 2D Helmholtz equation BIE operators
+function kernelvals(op::HH2DNear{T, K}, x, y) where {T, K <: Complex}
 
     γ = op.gamma
+    # Even though the evaluation of the Hankel function delivers
+    # in general a complex output (sole exception if wavenumber is purely imaginary)
+    # the Hankel function is evaluated much faster if the wavenumber, and thus
+    # the argument of the Hankelfunction, is purely real
     if iszero(real(γ))
         k = imag(γ)
     else
         k = -im*γ
     end
-    x = cartesian(p)
-    r = y - x
+    yc = cartesian(y)
+    xc = cartesian(x)
+    r = xc - yc
     R = norm(r)
 
     kR = k * R
     hankels = hankelh2.([0 1], kR)
-    #green = - op.alpha * im / 4 * hankels[1]
-    #gradgreen = op.alpha * k * im / 4 * hankels[2] * r / R
     green = - im / 4 * hankels[1]
-    gradgreen =  k * im / 4 * hankels[2] * r / R
+    gradgreen = k * im / 4 * hankels[2] * r / R
 
-    ddhankel = hankels[1] - 1/(kR) * hankels[2]
-
-    #txty = dot(normal(tgeo), normal(bgeo))
-
-    nx = normal(p)
-    tx = tangents(p, 1) / norm(tangents(p, 1))
-
-    # Needed for hypersingular operator
-    gradnxgradgreen = ddhankel * (k^2/R^2 * dot(r, nx) * r)
-    gradnxgradgreen += k * hankels[2] * (nx / R - r/R^3 * dot(r, nx)) 
-    gradnxgradgreen *= - im / 4
-
-    (;γ, r, R, green, gradgreen, nx, tx, gradnxgradgreen)
+    return KernelValsHH2DNear(γ, r, R, green, gradgreen)
 end
 
-function integrand(op::HH2DSingleLayerNear, krn, y, f, p)
+
+function integrand(op::HH2DSingleLayerNear, krn, x, g, y)
 
     α = op.alpha
     G = krn.green
-    fx = f.value
+    gy = g.value
 
-    return α * G * fx
+    return α * G * gy
 end
 
-function integrand(op::HH2DDoubleLayerNear, krn, y, f, p)
+function integrand(op::HH2DDoubleLayerNear, krn, x, g, y)
 
     α = op.alpha
     ∇G = -krn.gradgreen
-    nx = krn.nx
+    ny = normal(y)
+    gy = g.value
+    ∂G∂n = dot(ny, ∇G)
 
-    fx = f.value
-
-    ∂G∂n = nx ⋅ ∇G
-
-    return α * ∂G∂n * fx
+    return α * ∂G∂n * gy
 end
 
-function integrand(op::HH2DDoubleLayerTransposedNear, krn, y, f, p)
+function integrand(op::HH2DDoubleLayerTransposedNear, krn, x, g, y)
 
     α = op.alpha
     ∇G = krn.gradgreen
-    fx = f.value
+    gy = g.value
 
-    return α * ∇G * fx
+    return α * ∇G * gy
 end
 
-function integrand(op::HH2DHyperSingularNear, krn, y, f, p)
+function integrand(op::HH2DHyperSingularNear, krn, x, g, y)
+
     α = op.alpha
     β = op.beta
-
     G = krn.green
     ∇G = -krn.gradgreen
-
-    #∇nₓ∇ₓG = krn.gradnxgradgreen
-
-    fx = f.value
-    dfx = f.derivative
-    tx = krn.tx
+    gy = g.value
+    dgy = g.derivative
+    ty = tangents(y, 1) / norm(tangents(y, 1))
 
     # Based on (2.86) in Kumagai et al, “Integral equation methods for electromagnetics”
     # The formula returns the electric field, but we like to match the behavior of the
     # dyadic hypersingular operator and this requires an additional rotation
-    return cross(ẑ, -α * G * tx * fx + β * ∇G * dfx)
+    return cross(ẑ, (-α * G * ty * gy + β * ∇G * dgy))
 end
+
+function integrand(op::HH2DHyperSingularNear{T, K}, krn, x, g, y) where {T, K <: Val{0}}
+
+    β = op.beta
+    ∇G = -krn.gradgreen
+    dgy = g.derivative
+
+    return cross(ẑ, β * ∇G * dgy)
+end
+
+function defaultquadstrat(op::BEAST.HH2DNear, X::BEAST.Space)
+    return defaultquadstrat(op, X, X)
+end
+defaultquadstrat(op::HH2DNear, tfs, bfs) = SingleNumQStrat(3)
+quaddata(op::HH2DNear,rs,els,qs::SingleNumQStrat) = quadpoints(rs,els,(qs.quad_rule,))
+quadrule(op::HH2DNear,refspace,p,y,q,el,qdata,qs::SingleNumQStrat) = qdata[1,q]

--- a/src/helmholtz2d/hh2dops.jl
+++ b/src/helmholtz2d/hh2dops.jl
@@ -1,4 +1,5 @@
 import SpecialFunctions: hankelh2
+import SpecialFunctions: besselk
 
 abstract type HelmholtzOperator2D{T, K} <: IntegralOperator end
 
@@ -108,99 +109,127 @@ mutable struct KernelValsHelmholtz2D{K1,K2,F}
     dist::F
     green::K2
     gradgreen::SVector{2,K2}
-    txty::F
 end
 
 # Kernel values for 2D Laplace BIE operators
-function kernelvals(biop::HelmholtzOperator2D{T, K}, tgeo, bgeo) where {T, K <: Val{0}}
+function kernelvals(biop::HelmholtzOperator2D{T, K}, x, y) where {T, K <: Val{0}}
 
-    error("We currently do not support 2D Laplace equation")
+    yc = cartesian(y)
+    xc = cartesian(x)
+    r = xc - yc
+    R = norm(r)
+
+    #Treatment: static limit (HelmholtzOperator2D ~> "LaplaceOperator2D") Δu = 0 (k, γ -> 0)
+    #Logarithmic singularity of Hankel function: Gk = -1/(2π) * log(kR) (at static case, lnk = 0)
+    green = -1/(2π) * log(R)
+    gradgreen = -1/(2π) * (1/R) * (r/R)
+
+    return KernelValsHelmholtz2D(nothing, r, R, green, gradgreen)
 end
 
 # Kernel values for 2D modified Helmholtz equation BIE operators
-function kernelvals(biop::HelmholtzOperator2D{T, K}, tgeo, bgeo) where {T, K <: Real}
+function kernelvals(biop::HelmholtzOperator2D{T, K}, x, y) where {T, K <: Real}
 
-    error("We currently do not support 2D modified Helmholtz equation")
+    γ = biop.gamma
+    yc = cartesian(y)
+    xc = cartesian(x)
+    r = xc - yc
+    R = norm(r)
+
+    # Modified Helmholtz equation assumes: Δu - k² u = Δu + γ² u = f
+    # Green's function: Gγ = 1/(2π)* K0(γ |x - y|)
+    green = 1/(2π) * besselk(0, γ * R)
+    # Jin (pg. 713, C.5.9): dK0/dn = -dK1/dn
+    gradgreen = -γ/(2π) * besselk(1, γ * R) * (r/R)
+
+    return KernelValsHelmholtz2D(γ, r, R, green, gradgreen)
 end
 
 # Kernel values for 2D Helmholtz equation BIE operators
-function kernelvals(biop::HelmholtzOperator2D{T, K}, tgeo, bgeo) where {T, K <: Complex}
+function kernelvals(biop::HelmholtzOperator2D{T, K}, x, y) where {T, K <: Complex}
 
     # Even though the evaluation of the Hankel function delivers
     # in general a complex output (sole exception if wavenumber is purely imaginary)
     # the Hankel function is evaluated much faster if the wavenumber, and thus
     # the argument of the Hankelfunction, is purely real
-    if iszero(real(biop.gamma))
-        k = imag(biop.gamma)
+    γ = biop.gamma
+    if iszero(real(γ))
+        k = imag(γ)
     else
-        k = -im*biop.gamma
+        k = -im*γ
     end
-    r = tgeo.cart - bgeo.cart
+    yc = cartesian(y)
+    xc = cartesian(x)
+    r = xc - yc
     R = norm(r)
 
-    kr = k * R
-    hankels = hankelh2.([0 1], kr)
+    hankels = hankelh2.([0 1], k * R)
     green = - im / 4 * hankels[1]
+    gradgreen = k * im / 4 * hankels[2] * (r/R)
 
-    # Gradient with respect to observation point
-    gradgreen = k * im / 4 * hankels[2] * r / R
-
-    txty = dot(normal(tgeo), normal(bgeo))
-
-    KernelValsHelmholtz2D(biop.gamma, r, R, green, gradgreen, txty)
+    return KernelValsHelmholtz2D(γ, r, R, green, gradgreen)
 end
 
-shapevals(op::HelmholtzOperator2D, ϕ, ts) = shapevals(ValDiff(), ϕ, ts)
+function integrand(op::HH2DSingleLayerFDBIO, krn, f, x, g, y)
 
-function integrand(biop::HH2DSingleLayerFDBIO, kerneldata, tvals,
-    tgeo, bvals, bgeo)
+    α = op.alpha
+    G = krn.green
+    fx = f.value
+    gy = g.value
 
-    α = biop.alpha
-
-    gx = tvals[1]
-    fy = bvals[1]
-
-    return α * gx * kerneldata.green * fy
+    return α * G * fx * gy
 end
 
-function integrand(biop::HH2DDoubleLayerFDBIO, kernel, fp, mp, fq, mq)
-    nq = normal(mq)
+function integrand(op::HH2DDoubleLayerFDBIO, krn, f, x, g, y)
 
-    α = biop.alpha
+    α = op.alpha
+    ∇G = krn.gradgreen
+    ny = normal(y)
+    fx = f.value
+    gy = g.value
+    ∂G∂n = dot(ny, -∇G)
 
-    return α * fp[1] * dot(nq, -kernel.gradgreen) * fq[1]
+    return α * ∂G∂n * fx * gy
 end
 
-function integrand(biop::HH2DDoubleLayerTransposedFDBIO, kernel, fp, mp, fq, mq)
-    np = normal(mp)
+function integrand(op::HH2DDoubleLayerTransposedFDBIO, krn, f, x, g, y)
 
-    α = biop.alpha
+    α = op.alpha
+    ∇G = krn.gradgreen
+    nx = normal(x)
+    fx = f.value
+    gy = g.value
+    ∂G∂n = dot(nx, ∇G)
 
-    return α * fp[1] * dot(np, kernel.gradgreen) * fq[1]
+    return α * ∂G∂n * fx * gy
 end
 
-function integrand(biop::HH2DHyperSingularFDBIO, kernel, tvals, tgeo,
-    bvals, bgeo)
+function integrand(op::HH2DHyperSingularFDBIO, krn, f, x, g, y)
 
-    α = biop.alpha
-    β = biop.beta
+    α = op.alpha
+    β = op.beta
+    G = krn.green
+    fx = f.value
+    dfx = f.derivative
+    gy = g.value
+    dgy = g.derivative
 
-    gx = tvals[1]
-    fy = bvals[1]
+    nxny = dot(normal(x), normal(y))
 
-    dgx = tvals[2]
-    dfy = bvals[2]
-
-    G    = kernel.green
-    txty = kernel.txty
-
-    return (α * txty * gx * fy + β * dgx * dfy) * G
+    # Based on (2.86) in Kumagai et al, “Integral equation methods for electromagnetics”
+    # The formula returns the electric field, but we like to match the behavior of the
+    # dyadic hypersingular operator and this requires an additional rotation
+    return (α * fx * gy * nxny + β * dfx * dgy) * G
 end
 
-function cellcellinteractions!(biop::HelmholtzOperator2D, tshs, bshs, tcell, bcell, z)
+function integrand(op::HH2DHyperSingularFDBIO{T, K}, krn, f, x, g, y) where {T, K <: Val{0}}
 
-    regularcellcellinteractions!(biop, tshs, bshs, tcell, bcell, z)
+    β = op.beta
+    G = krn.green
+    dfx = f.derivative
+    dgy = g.derivative
 
+    return (β * dfx * dgy) * G
 end
 
 defaultquadstrat(op::HelmholtzOperator2D, tfs, bfs) = DoubleNumSauterQstrat(30,30,0,4,25,25)

--- a/test/test_hh2d_nearfield.jl
+++ b/test/test_hh2d_nearfield.jl
@@ -26,7 +26,7 @@ using Test
 
     # Interior problem
     # Formulations from Sauter and Schwab, Boundary Element Methods(2011), Chapter 3.4.1.1
-  
+
     pos1 = SVector(r * 1.5, 0.0)  # positioning of point charges
     pos2 = SVector(-r * 1.5, 0.0)
 
@@ -87,7 +87,7 @@ using Test
     err_INPSL_field = norm(field_INPSL + Efield.(pts)) / norm(Efield.(pts))
     err_INPDL_field = norm(field_INPDL + Efield.(pts)) / norm(Efield.(pts))
 
-    # Exterior problem 
+    # Exterior problem
     # formulations from Sauter and Schwab, Boundary Element Methods(2011), Chapter 3.4.1.2
 
     pos1 = SVector(r * 0.5, 0.0)
@@ -154,6 +154,482 @@ using Test
     @test err_EDPDL_pot < 1e-3
     @test err_ENPSL_pot < 1e-3
     @test err_ENPDL_pot < 1e-3
+
+    @test err_EDPSL_field < 1e-2
+    @test err_EDPDL_field < 1e-2
+    @test err_ENPSL_field < 1e-2
+    @test err_ENPDL_field < 1e-2
+end
+
+@testset "2D-Laplace potential operators (k = 0)" begin
+    k = 0.0
+    r = 10.0
+    circle = CompScienceMeshes.meshcircle(r, 1.0)
+
+    X0 = lagrangecxd0(circle)
+    X1 = lagrangec0d1(circle)
+
+    S = Helmholtz2D.singlelayer(;)
+    D = Helmholtz2D.doublelayer(;)
+    Dt = Helmholtz2D.doublelayer_transposed(;)
+    N = Helmholtz2D.hypersingular(;)
+
+
+    q = 100.0
+    ϵ = 1.0
+
+    # Interior problem
+    # Formulations from Sauter and Schwab, Boundary Element Methods(2011), Chapter 3.4.1.1
+
+    pos1 = SVector(r * 1.5, 0.0)  # positioning of point charges
+    pos2 = SVector(-r * 1.5, 0.0)
+
+    charge1 = Helmholtz2D.monopole(position=pos1, amplitude=q/(4*π*ϵ))
+    charge2 = Helmholtz2D.monopole(position=pos2, amplitude=-q/(4*π*ϵ))
+
+    # Potential of point charges
+    Φ_inc(x) = charge1(x) + charge2(x)
+
+    gD0 = assemble(DirichletTrace(charge1), X0) + assemble(DirichletTrace(charge2), X0)
+    gD1 = assemble(DirichletTrace(charge1), X1) + assemble(DirichletTrace(charge2), X1)
+    gN = assemble(∂n(charge1), X1) + assemble(BEAST.n ⋅ grad(charge2), X1)
+
+    G = assemble(Identity(), X1, X1)
+    o = ones(numfunctions(X1))
+
+    # Interior Dirichlet problem - compare Sauter & Schwab eqs. 3.81
+    M_IDPSL = assemble(S, X0, X0) # Single layer (SL)
+    M_IDPDL = (-1 / 2 * G + assemble(D, X1, X1)) # Double layer (DL)
+
+    # Interior Neumann problem
+    # Neumann derivative from DL potential with deflected nullspace
+    M_INPDL = assemble(N, X1, X1) + G * o * o' * G
+    # Neumann derivative from SL potential with deflected nullspace
+    M_INPSL = (1 / 2 * G + assemble(Dt, X1, X1)) + G * o * o' * G
+
+    ρ_IDPSL = M_IDPSL \ (-gD0)
+    ρ_IDPDL = M_IDPDL \ (-gD1)
+
+    ρ_INPSL = M_INPSL \ (-gN)
+    ρ_INPDL = M_INPDL \ (gN)
+
+    pts = meshcircle(0.8 * r, 0.8 * 0.6 * r).vertices # sphere inside on which the potential and field are evaluated
+
+    pot_IDPSL = potential(HH2DSingleLayerNear(S), pts, ρ_IDPSL, X0; type=ComplexF64)
+    pot_IDPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_IDPDL, X1; type=ComplexF64)
+    pot_INPSL = potential(HH2DSingleLayerNear(S), pts, ρ_INPSL, X1; type=ComplexF64)
+    pot_INPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_INPDL, X1; type=ComplexF64)
+
+    # Total field inside should be zero
+    err_IDPSL_pot = norm(pot_IDPSL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+    err_IDPDL_pot = norm(pot_IDPDL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+    err_INPSL_pot = norm(pot_INPSL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+    err_INPDL_pot = norm(pot_INPDL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+
+    # Efield(x) = - grad Φ_inc(x)
+    Efield(x) =  -grad(charge1)(x) + -grad(charge2)(x)
+
+    field_IDPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_IDPSL, X0; type=SVector{2,ComplexF64})
+    field_IDPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_IDPDL, X1; type=SVector{2,ComplexF64})
+    field_INPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_INPSL, X1; type=SVector{2,ComplexF64})
+    field_INPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_INPDL, X1; type=SVector{2,ComplexF64})
+
+    err_IDPSL_field = norm(field_IDPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_IDPDL_field = norm(field_IDPDL + Efield.(pts)) / norm(Efield.(pts))
+    err_INPSL_field = norm(field_INPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_INPDL_field = norm(field_INPDL + Efield.(pts)) / norm(Efield.(pts))
+
+
+    # Exterior problem
+    # formulations from Sauter and Schwab, Boundary Element Methods(2011), Chapter 3.4.1.2
+
+    pos1 = SVector(r * 0.5, 0.0)
+    pos2 = SVector(-r * 0.5, 0.0)
+
+    charge1 = Helmholtz2D.monopole(position=pos1, amplitude=q/(4*π*ϵ))
+    charge2 = Helmholtz2D.monopole(position=pos2, amplitude=-q/(4*π*ϵ))
+
+    gD0 = assemble(DirichletTrace(charge1), X0) + assemble(DirichletTrace(charge2), X0)
+    gD1 = assemble(DirichletTrace(charge1), X1) + assemble(DirichletTrace(charge2), X1)
+    gN = assemble(∂n(charge1), X1) + assemble(∂n(charge2), X1)
+
+    G = assemble(Identity(), X1, X1)
+    o = ones(numfunctions(X1))
+
+    M_EDPSL = assemble(S, X0, X0)
+    # Dirichlet condition from DL potential with deflected nullspace
+    M_EDPDL = (1 / 2 * G + assemble(D, X1, X1)) + G * o * o' * G
+
+    # Neumann derivative from DL potential with deflected nullspace
+    M_ENPDL = assemble(N, X1, X1)# + G * o * o' * G
+    M_ENPSL = (-1 / 2 * G + assemble(Dt, X1, X1))
+
+    ρ_EDPSL = M_EDPSL \ (-gD0)
+    ρ_EDPDL = M_EDPDL \ (-gD1)
+
+    ρ_ENPDL = M_ENPDL \ gN
+    ρ_ENPSL = M_ENPSL \ (-gN)
+
+    testcircle = meshcircle(1.2 * r, 1.2 * 0.6 * r)
+    pts = testcircle.vertices[norm.(testcircle.vertices) .> r]
+
+    pot_EDPSL = potential(HH2DSingleLayerNear(S), pts, ρ_EDPSL, X0; type=ComplexF64)
+    pot_EDPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_EDPDL, X1; type=ComplexF64)
+    pot_ENPSL = potential(HH2DSingleLayerNear(S), pts, ρ_ENPSL, X1; type=ComplexF64)
+    pot_ENPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_ENPDL, X1; type=ComplexF64)
+
+    err_EDPSL_pot = norm(pot_EDPSL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+    err_EDPDL_pot = norm(pot_EDPDL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+    err_ENPSL_pot = norm(pot_ENPSL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+    err_ENPDL_pot = norm(pot_ENPDL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+
+    field_EDPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_EDPSL, X0; type=SVector{2,ComplexF64})
+    field_EDPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_EDPDL, X1; type=SVector{2,ComplexF64})
+    field_ENPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_ENPSL, X1; type=SVector{2,ComplexF64})
+    field_ENPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_ENPDL, X1; type=SVector{2,ComplexF64})
+
+    err_EDPSL_field = norm(field_EDPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_EDPDL_field = norm(field_EDPDL + Efield.(pts)) / norm(Efield.(pts))
+    err_ENPSL_field = norm(field_ENPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_ENPDL_field = norm(field_ENPDL + Efield.(pts)) / norm(Efield.(pts))
+
+    # errors of interior problems
+    @test err_IDPSL_pot < 1e-3
+    @test err_IDPDL_pot < 1e-3
+    @test err_INPSL_pot < 1e-3
+    @test err_INPDL_pot < 1e-3
+
+    @test err_IDPSL_field < 1e-2
+    @test err_IDPDL_field < 1e-2
+    @test err_INPSL_field < 1e-2
+    @test err_INPDL_field < 1e-2
+
+    # errors of exterior problems
+    @test err_EDPSL_pot < 1e-3
+    @test err_EDPDL_pot < 1e-3
+    @test err_ENPSL_pot < 1e-3
+    @test err_ENPDL_pot < 1e-3
+
+    @test err_EDPSL_field < 1e-2
+    @test err_EDPDL_field < 1e-2
+    @test err_ENPSL_field < 1e-2
+    @test err_ENPDL_field < 1e-2
+end
+
+@testset "2D-Helmholtz potential operators (γ complex)" begin
+    k = 1.0
+    r = 10.0
+    circle = CompScienceMeshes.meshcircle(r, 1.0)
+
+    X0 = lagrangecxd0(circle)
+    X1 = lagrangec0d1(circle)
+
+    S = Helmholtz2D.singlelayer(wavenumber = k)
+    D = Helmholtz2D.doublelayer(wavenumber = k)
+    Dt = Helmholtz2D.doublelayer_transposed(wavenumber = k)
+    N = Helmholtz2D.hypersingular(wavenumber = k)
+
+
+    q = 100.0
+    ϵ = 1.0
+
+    # Interior problem
+    # Formulations from Sauter and Schwab, Boundary Element Methods(2011), Chapter 3.4.1.1
+
+    pos1 = SVector(r * 1.5, 0.0)  # positioning of point charges
+    pos2 = SVector(-r * 1.5, 0.0)
+
+    charge1 = Helmholtz2D.monopole(position=pos1, amplitude=q/(4*π*ϵ), wavenumber=k)
+    charge2 = Helmholtz2D.monopole(position=pos2, amplitude=-q/(4*π*ϵ), wavenumber=k)
+
+    # Potential of point charges
+    Φ_inc(x) = charge1(x) + charge2(x)
+
+    gD0 = assemble(DirichletTrace(charge1), X0) + assemble(DirichletTrace(charge2), X0)
+    gD1 = assemble(DirichletTrace(charge1), X1) + assemble(DirichletTrace(charge2), X1)
+    gN = assemble(∂n(charge1), X1) + assemble(BEAST.n ⋅ grad(charge2), X1)
+
+    G = assemble(Identity(), X1, X1)
+    o = ones(numfunctions(X1))
+
+    # Interior Dirichlet problem - compare Sauter & Schwab eqs. 3.81
+    M_IDPSL = assemble(S, X0, X0) # Single layer (SL)
+    M_IDPDL = (-1 / 2 * G + assemble(D, X1, X1)) # Double layer (DL)
+
+    # Interior Neumann problem
+    # Neumann derivative from DL potential with deflected nullspace
+    M_INPDL = assemble(N, X1, X1) + G * o * o' * G
+    # Neumann derivative from SL potential with deflected nullspace
+    M_INPSL = (1 / 2 * G + assemble(Dt, X1, X1))# + G * o * o' * G
+
+    #println(rank(M_INPDL))
+    #println(cond(M_INPDL))
+
+    ρ_IDPSL = M_IDPSL \ (-gD0)
+    ρ_IDPDL = M_IDPDL \ (-gD1)
+
+    ρ_INPSL = M_INPSL \ (-gN)
+    ρ_INPDL = M_INPDL \ (gN)
+
+    pts = meshcircle(0.8 * r, 0.8 * 0.6 * r).vertices # sphere inside on which the potential and field are evaluated
+
+    pot_IDPSL = potential(HH2DSingleLayerNear(S), pts, ρ_IDPSL, X0; type=ComplexF64)
+    pot_IDPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_IDPDL, X1; type=ComplexF64)
+    pot_INPSL = potential(HH2DSingleLayerNear(S), pts, ρ_INPSL, X1; type=ComplexF64)
+    pot_INPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_INPDL, X1; type=ComplexF64)
+
+    # Total field inside should be zero
+    err_IDPSL_pot = norm(pot_IDPSL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+    err_IDPDL_pot = norm(pot_IDPDL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+    err_INPSL_pot = norm(pot_INPSL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+    err_INPDL_pot = norm(pot_INPDL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+
+    # Efield(x) = - grad Φ_inc(x)
+    Efield(x) =  -grad(charge1)(x) + -grad(charge2)(x)
+
+    field_IDPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_IDPSL, X0; type=SVector{2,ComplexF64})
+    field_IDPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_IDPDL, X1; type=SVector{2,ComplexF64})
+    field_INPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_INPSL, X1; type=SVector{2,ComplexF64})
+    field_INPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_INPDL, X1; type=SVector{2,ComplexF64})
+
+    err_IDPSL_field = norm(field_IDPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_IDPDL_field = norm(field_IDPDL + Efield.(pts)) / norm(Efield.(pts))
+    err_INPSL_field = norm(field_INPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_INPDL_field = norm(field_INPDL + Efield.(pts)) / norm(Efield.(pts))
+
+    # Exterior problem
+    # formulations from Sauter and Schwab, Boundary Element Methods(2011), Chapter 3.4.1.2
+
+    pos1 = SVector(r * 0.5, 0.0)
+    pos2 = SVector(-r * 0.5, 0.0)
+
+    charge1 = Helmholtz2D.monopole(position=pos1, amplitude=q/(4*π*ϵ), wavenumber=k)
+    charge2 = Helmholtz2D.monopole(position=pos2, amplitude=-q/(4*π*ϵ), wavenumber=k)
+
+    gD0 = assemble(DirichletTrace(charge1), X0) + assemble(DirichletTrace(charge2), X0)
+    gD1 = assemble(DirichletTrace(charge1), X1) + assemble(DirichletTrace(charge2), X1)
+    gN = assemble(∂n(charge1), X1) + assemble(∂n(charge2), X1)
+
+    G = assemble(Identity(), X1, X1)
+    o = ones(numfunctions(X1))
+
+    M_EDPSL = assemble(S, X0, X0)
+    # Dirichlet condition from DL potential with deflected nullspace
+    M_EDPDL = (1 / 2 * G + assemble(D, X1, X1))# + G * o * o' * G
+
+    # Neumann derivative from DL potential with deflected nullspace
+    M_ENPDL = assemble(N, X1, X1) + G * o * o' * G
+    M_ENPSL = (-1 / 2 * G + assemble(Dt, X1, X1))
+
+    #println(rank(M_ENPDL))
+    #println(cond(M_ENPDL))
+
+    ρ_EDPSL = M_EDPSL \ (-gD0)
+    ρ_EDPDL = M_EDPDL \ (-gD1)
+
+    ρ_ENPDL = M_ENPDL \ gN
+    ρ_ENPSL = M_ENPSL \ (-gN)
+
+    testcircle = meshcircle(1.2 * r, 1.2 * 0.6 * r)
+    pts = testcircle.vertices[norm.(testcircle.vertices) .> r]
+
+    pot_EDPSL = potential(HH2DSingleLayerNear(S), pts, ρ_EDPSL, X0; type=ComplexF64)
+    pot_EDPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_EDPDL, X1; type=ComplexF64)
+    pot_ENPSL = potential(HH2DSingleLayerNear(S), pts, ρ_ENPSL, X1; type=ComplexF64)
+    pot_ENPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_ENPDL, X1; type=ComplexF64)
+
+    err_EDPSL_pot = norm(pot_EDPSL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+    err_EDPDL_pot = norm(pot_EDPDL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+    err_ENPSL_pot = norm(pot_ENPSL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+    err_ENPDL_pot = norm(pot_ENPDL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+
+    field_EDPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_EDPSL, X0; type=SVector{2,ComplexF64})
+    field_EDPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_EDPDL, X1; type=SVector{2,ComplexF64})
+    field_ENPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_ENPSL, X1; type=SVector{2,ComplexF64})
+    field_ENPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_ENPDL, X1; type=SVector{2,ComplexF64})
+
+    err_EDPSL_field = norm(field_EDPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_EDPDL_field = norm(field_EDPDL + Efield.(pts)) / norm(Efield.(pts))
+    err_ENPSL_field = norm(field_ENPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_ENPDL_field = norm(field_ENPDL + Efield.(pts)) / norm(Efield.(pts))
+
+    # errors of interior problems
+    @test err_IDPSL_pot < 1e-2
+    @test err_IDPDL_pot < 1e-2
+    @test err_INPSL_pot < 1e-2
+    @test err_INPDL_pot < 1e-2
+
+    @test err_IDPSL_field < 1e-2
+    @test err_IDPDL_field < 1e-2
+    @test err_INPSL_field < 1e-2
+    @test err_INPDL_field < 1e-2
+
+    # errors of exterior problems
+    @test err_EDPSL_pot < 1e-2
+    @test err_EDPDL_pot < 1e-2
+    @test err_ENPSL_pot < 1e-2
+    @test err_ENPDL_pot < 1e-2
+
+    @test err_EDPSL_field < 1e-2
+    @test err_EDPDL_field < 1e-2
+    @test err_ENPSL_field < 1e-2
+    @test err_ENPDL_field < 1e-2
+end
+
+@testset "2D-Helmholtz modified potential operators (k purely imaginary, γ real)" begin
+    k = -1.0*im
+    r = 10.0
+    circle = CompScienceMeshes.meshcircle(r, 1.0)
+    # gamma = im*k
+    # isreal(gamma)
+    X0 = lagrangecxd0(circle)
+    X1 = lagrangec0d1(circle)
+
+    S = Helmholtz2D.singlelayer(wavenumber = k)
+    D = Helmholtz2D.doublelayer(wavenumber = k)
+    Dt = Helmholtz2D.doublelayer_transposed(wavenumber = k)
+    N = Helmholtz2D.hypersingular(wavenumber = k)
+
+
+    q = 100.0
+    ϵ = 1.0
+
+    # Interior problem
+    # Formulations from Sauter and Schwab, Boundary Element Methods(2011), Chapter 3.4.1.1
+
+    pos1 = SVector(r * 1.5, 0.0)  # positioning of point charges
+    pos2 = SVector(-r * 1.5, 0.0)
+
+    charge1 = Helmholtz2D.monopole(position=pos1, amplitude=q/(4*π*ϵ), wavenumber=k)
+    charge2 = Helmholtz2D.monopole(position=pos2, amplitude=-q/(4*π*ϵ), wavenumber=k)
+
+    # Potential of point charges
+    Φ_inc(x) = charge1(x) + charge2(x)
+
+    gD0 = assemble(DirichletTrace(charge1), X0) + assemble(DirichletTrace(charge2), X0)
+    gD1 = assemble(DirichletTrace(charge1), X1) + assemble(DirichletTrace(charge2), X1)
+    gN = assemble(∂n(charge1), X1) + assemble(BEAST.n ⋅ grad(charge2), X1)
+
+    G = assemble(Identity(), X1, X1)
+    o = ones(numfunctions(X1))
+
+    # Interior Dirichlet problem - compare Sauter & Schwab eqs. 3.81
+    M_IDPSL = assemble(S, X0, X0) # Single layer (SL)
+    M_IDPDL = (-1 / 2 * G + assemble(D, X1, X1)) # Double layer (DL)
+
+    # Interior Neumann problem
+    # Neumann derivative from DL potential with deflected nullspace
+    M_INPDL = assemble(N, X1, X1) + G * o * o' * G
+    # Neumann derivative from SL potential with deflected nullspace
+    M_INPSL = (1 / 2 * G + assemble(Dt, X1, X1))# + G * o * o' * G
+
+    #println(rank(M_INPDL))
+    #println(cond(M_INPDL))
+
+    ρ_IDPSL = M_IDPSL \ (-gD0)
+    ρ_IDPDL = M_IDPDL \ (-gD1)
+
+    ρ_INPSL = M_INPSL \ (-gN)
+    ρ_INPDL = M_INPDL \ (gN)
+
+    pts = meshcircle(0.8 * r, 0.8 * 0.6 * r).vertices # sphere inside on which the potential and field are evaluated
+
+    pot_IDPSL = potential(HH2DSingleLayerNear(S), pts, ρ_IDPSL, X0; type=ComplexF64)
+    pot_IDPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_IDPDL, X1; type=ComplexF64)
+    pot_INPSL = potential(HH2DSingleLayerNear(S), pts, ρ_INPSL, X1; type=ComplexF64)
+    pot_INPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_INPDL, X1; type=ComplexF64)
+
+    # Total field inside should be zero
+    err_IDPSL_pot = norm(pot_IDPSL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+    err_IDPDL_pot = norm(pot_IDPDL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+    err_INPSL_pot = norm(pot_INPSL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+    err_INPDL_pot = norm(pot_INPDL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+
+    # Efield(x) = - grad Φ_inc(x)
+    Efield(x) =  -grad(charge1)(x) + -grad(charge2)(x)
+
+    field_IDPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_IDPSL, X0; type=SVector{2,ComplexF64})
+    field_IDPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_IDPDL, X1; type=SVector{2,ComplexF64})
+    field_INPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_INPSL, X1; type=SVector{2,ComplexF64})
+    field_INPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_INPDL, X1; type=SVector{2,ComplexF64})
+
+    err_IDPSL_field = norm(field_IDPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_IDPDL_field = norm(field_IDPDL + Efield.(pts)) / norm(Efield.(pts))
+    err_INPSL_field = norm(field_INPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_INPDL_field = norm(field_INPDL + Efield.(pts)) / norm(Efield.(pts))
+
+    # Exterior problem
+    # formulations from Sauter and Schwab, Boundary Element Methods(2011), Chapter 3.4.1.2
+
+    pos1 = SVector(r * 0.5, 0.0)
+    pos2 = SVector(-r * 0.5, 0.0)
+
+    charge1 = Helmholtz2D.monopole(position=pos1, amplitude=q/(4*π*ϵ), wavenumber=k)
+    charge2 = Helmholtz2D.monopole(position=pos2, amplitude=-q/(4*π*ϵ), wavenumber=k)
+
+    gD0 = assemble(DirichletTrace(charge1), X0) + assemble(DirichletTrace(charge2), X0)
+    gD1 = assemble(DirichletTrace(charge1), X1) + assemble(DirichletTrace(charge2), X1)
+    gN = assemble(∂n(charge1), X1) + assemble(∂n(charge2), X1)
+
+    G = assemble(Identity(), X1, X1)
+    o = ones(numfunctions(X1))
+
+    M_EDPSL = assemble(S, X0, X0)
+    # Dirichlet condition from DL potential with deflected nullspace
+    M_EDPDL = (1 / 2 * G + assemble(D, X1, X1))# + G * o * o' * G
+
+    # Neumann derivative from DL potential with deflected nullspace
+    M_ENPDL = assemble(N, X1, X1) + G * o * o' * G
+    M_ENPSL = (-1 / 2 * G + assemble(Dt, X1, X1))
+
+    #println(rank(M_ENPDL))
+    #println(cond(M_ENPDL))
+
+    ρ_EDPSL = M_EDPSL \ (-gD0)
+    ρ_EDPDL = M_EDPDL \ (-gD1)
+
+    ρ_ENPDL = M_ENPDL \ gN
+    ρ_ENPSL = M_ENPSL \ (-gN)
+
+    testcircle = meshcircle(1.2 * r, 1.2 * 0.6 * r)
+    pts = testcircle.vertices[norm.(testcircle.vertices) .> r]
+
+    pot_EDPSL = potential(HH2DSingleLayerNear(S), pts, ρ_EDPSL, X0; type=ComplexF64)
+    pot_EDPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_EDPDL, X1; type=ComplexF64)
+    pot_ENPSL = potential(HH2DSingleLayerNear(S), pts, ρ_ENPSL, X1; type=ComplexF64)
+    pot_ENPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_ENPDL, X1; type=ComplexF64)
+
+    err_EDPSL_pot = norm(pot_EDPSL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+    err_EDPDL_pot = norm(pot_EDPDL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+    err_ENPSL_pot = norm(pot_ENPSL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+    err_ENPDL_pot = norm(pot_ENPDL + Φ_inc.(pts)) ./ norm(Φ_inc.(pts))
+
+    field_EDPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_EDPSL, X0; type=SVector{2,ComplexF64})
+    field_EDPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_EDPDL, X1; type=SVector{2,ComplexF64})
+    field_ENPSL = -potential(HH2DDoubleLayerTransposedNear(Dt), pts, ρ_ENPSL, X1; type=SVector{2,ComplexF64})
+    field_ENPDL = -potential(HH2DHyperSingularNear(N), pts, ρ_ENPDL, X1; type=SVector{2,ComplexF64})
+
+    err_EDPSL_field = norm(field_EDPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_EDPDL_field = norm(field_EDPDL + Efield.(pts)) / norm(Efield.(pts))
+    err_ENPSL_field = norm(field_ENPSL + Efield.(pts)) / norm(Efield.(pts))
+    err_ENPDL_field = norm(field_ENPDL + Efield.(pts)) / norm(Efield.(pts))
+
+    # errors of interior problems
+    @test err_IDPSL_pot < 1e-2
+    @test err_IDPDL_pot < 1e-2
+    @test err_INPSL_pot < 1e-2
+    @test err_INPDL_pot < 1e-2
+
+    @test err_IDPSL_field < 1e-2
+    @test err_IDPDL_field < 1e-2
+    @test err_INPSL_field < 1e-2
+    @test err_INPDL_field < 1e-2
+
+    # errors of exterior problems
+    @test err_EDPSL_pot < 1e-2
+    @test err_EDPDL_pot < 1e-2
+    @test err_ENPSL_pot < 1e-2
+    @test err_ENPDL_pot < 1e-2
 
     @test err_EDPSL_field < 1e-2
     @test err_EDPDL_field < 1e-2


### PR DESCRIPTION
Until now we lacked static and modified Helmholtz kernels in 2D. They are now added.

The work comprises also some cleanup and refactoring. In particular, instead of tgeo and bgeo, we use consistently x (observation) and y (source), also in the nearfield part.

TODO:
The default quadstrat is excessively high, but it would require changing the thresholds in the unit tests. I believe this should be done in a separate PR to keep these changes clearly separated for easier debugging.