### PR TITLE
Telles near singularity treatment

### DIFF
--- a/src/BEAST.jl
+++ b/src/BEAST.jl
@@ -254,6 +254,8 @@ include("quadrature/nonconformingtouchqrule.jl")
 include("quadrature/rules/testrefinestrialqrule.jl")
 include("quadrature/rules/trialrefinestestqrule.jl")
 include("quadrature/rules/testinbaryrefoftrialqrule.jl")
+include("quadrature/tellesquadrature.jl")
+include("quadrature/tellesints.jl")
 
 include("postproc.jl")
 include("postproc/segcurrents.jl")

--- a/src/helmholtz2d/hh2dnear.jl
+++ b/src/helmholtz2d/hh2dnear.jl
@@ -200,6 +200,29 @@ end
 function defaultquadstrat(op::BEAST.HH2DNear, X::BEAST.Space)
     return defaultquadstrat(op, X, X)
 end
-defaultquadstrat(op::HH2DNear, tfs, bfs) = SingleNumQStrat(3)
-quaddata(op::HH2DNear,rs,els,qs::SingleNumQStrat) = quadpoints(rs,els,(qs.quad_rule,))
-quadrule(op::HH2DNear,refspace,p,y,q,el,qdata,qs::SingleNumQStrat) = qdata[1,q]
+
+#defaultquadstrat(op::HH2DNear, tfs, bfs) = SingleNumQStrat(3)
+defaultquadstrat(op::HH2DNear, tfs, bfs) = SingleNumTellesQStrat(3, 3)
+quaddata(op::HH2DNear, rs, els, qs::SingleNumQStrat) = quadpoints(rs, els, (qs.quad_rule,))
+
+function quaddata(op::HH2DNear, rs, els, qs::SingleNumTellesQStrat)
+
+    T = coordtype(els[1])
+
+    leg = quadpoints(rs, els, (qs.gauss_rule,))
+
+    tel = _legendre(qs.telles_rule, -1.0, 1.0)
+
+    return (gauss=leg, telles=tel)
+end
+
+quadrule(op::HH2DNear, refspace, p, y, q, el, qdata, qs::SingleNumQStrat) = qdata[1, q]
+
+function quadrule(op::HH2DNear, refspace, p,
+    y, q, el, qd, qs::SingleNumTellesQStrat)
+    test_midpoint = cartesian(neighborhood(el, 0.5))
+    if ((norm(test_midpoint - y) / el.volume) <= 1)
+        return BEAST.TellesQuadrature.TellesRule1D(qd.telles)
+    end
+    return SingleNumQRule(qd.gauss[1, q])
+end

--- a/src/helmholtz2d/hh2dops.jl
+++ b/src/helmholtz2d/hh2dops.jl
@@ -240,37 +240,126 @@ function quaddata(op::HelmholtzOperator2D,
 
     T = coordtype(test_charts[1])
 
-    tqd = quadpoints(test_local_space,  test_charts,  (qs.outer_rule,))
+    tqd = quadpoints(test_local_space, test_charts, (qs.outer_rule,))
     bqd = quadpoints(trial_local_space, trial_charts, (qs.inner_rule,))
 
     leg = (
-      convert.(NTuple{2,T},_legendre(qs.sauter_schwab_common_vert,0,1)),
-      convert.(NTuple{2,T},_legendre(qs.sauter_schwab_common_edge,0,1)),
-      convert.(NTuple{2,T},_legendre(qs.sauter_schwab_common_face,0,1)),
+        convert.(NTuple{2,T}, _legendre(qs.sauter_schwab_common_vert, 0, 1)),
+        convert.(NTuple{2,T}, _legendre(qs.sauter_schwab_common_edge, 0, 1)),
+        convert.(NTuple{2,T}, _legendre(qs.sauter_schwab_common_face, 0, 1)),
     )
 
     mrw = (
-     convert.(NTuple{2,T},BEAST.SauterSchwabQuadrature1D._MRWrules(qs.sauter_schwab_common_vert,0,1)),
-     convert.(NTuple{2,T},BEAST.SauterSchwabQuadrature1D._MRWrules(qs.sauter_schwab_common_edge,0,1)),
-     convert.(NTuple{2,T},BEAST.SauterSchwabQuadrature1D._MRWrules(qs.sauter_schwab_common_face,0,1)),
+        convert.(NTuple{2,T}, BEAST.SauterSchwabQuadrature1D._MRWrules(qs.sauter_schwab_common_vert, 0, 1)),
+        convert.(NTuple{2,T}, BEAST.SauterSchwabQuadrature1D._MRWrules(qs.sauter_schwab_common_edge, 0, 1)),
+        convert.(NTuple{2,T}, BEAST.SauterSchwabQuadrature1D._MRWrules(qs.sauter_schwab_common_face, 0, 1)),
     )
 
     return (tpoints=tqd, bpoints=bqd, gausslegendre=leg, marokhlinwandura=mrw)
 end
 
 function quadrule(op::HelmholtzOperator2D, g::LagrangeRefSpace, f::LagrangeRefSpace,
-    i, τ::CompScienceMeshes.Simplex{<:Any, 1},
-    j, σ::CompScienceMeshes.Simplex{<:Any, 1},
+    i, τ::CompScienceMeshes.Simplex{<:Any,1},
+    j, σ::CompScienceMeshes.Simplex{<:Any,1},
     qd, qs::DoubleNumSauterQstrat)
 
     hits = _numhits(τ, σ)
     @assert hits <= 2
 
-    hits == 2 && return BEAST.SauterSchwabQuadrature1D.CommonEdge(qd.marokhlinwandura[2], qd.gausslegendre[2])
-    hits == 1 && return BEAST.SauterSchwabQuadrature1D.CommonVertex(qd.marokhlinwandura[1], qd.gausslegendre[1])
+    hits == 2 && return BEAST.SauterSchwabQuadrature1D.CommonEdge(qd.marokhlinwandura[2],
+        qd.gausslegendre[2])
+    hits == 1 && return BEAST.SauterSchwabQuadrature1D.CommonVertex(qd.marokhlinwandura[1],
+        qd.gausslegendre[1])
 
     return DoubleQuadRule(
-        qd.tpoints[1,i],
-        qd.bpoints[1,j],
+        qd.tpoints[1, i],
+        qd.bpoints[1, j],
+    )
+end
+
+function quaddata(op::HelmholtzOperator2D,
+    test_local_space::RefSpace, trial_local_space::RefSpace,
+    test_charts, trial_charts, qs::DoubleNumSauterTellesQstrat)
+
+    T = coordtype(test_charts[1])
+
+    tqd = quadpoints(test_local_space, test_charts, (qs.outer_rule,))
+    bqd = quadpoints(trial_local_space, trial_charts, (qs.inner_rule,))
+
+    leg = (
+        convert.(NTuple{2,T}, _legendre(qs.sauter_schwab_common_vert, 0, 1)),
+        convert.(NTuple{2,T}, _legendre(qs.sauter_schwab_common_edge, 0, 1))
+    )
+
+    tel = (
+        convert.(NTuple{2,T}, _legendre(qs.telles_inner_rule, 0, 1)),
+        convert.(NTuple{2,T}, _legendre(qs.telles_outer_rule, 0, 1))
+    )
+
+    mrw = (
+        convert.(NTuple{2,T},
+            BEAST.SauterSchwabQuadrature1D._MRWrules(qs.sauter_schwab_common_vert, 0, 1)),
+        convert.(NTuple{2,T},
+            BEAST.SauterSchwabQuadrature1D._MRWrules(qs.sauter_schwab_common_edge, 0, 1))
+    )
+
+    return (tpoints=tqd, bpoints=bqd, gausslegendre=leg, telles=tel, marokhlinwandura=mrw)
+end
+
+function quadrule(op::HelmholtzOperator2D, g::LagrangeRefSpace, f::LagrangeRefSpace,
+    i, τ::CompScienceMeshes.Simplex{<:Any,1},
+    j, σ::CompScienceMeshes.Simplex{<:Any,1},
+    qd, qs::DoubleNumSauterTellesQstrat)
+    #Telles was found to be more accurate for angles ϕ<10°
+    max_angle_deg = 10
+    hits = _numhits(τ, σ)
+    @assert hits <= 2
+    if hits == 1            #Common Vertex case
+
+        #we find the angle between test and trial edge by using the tangents of the edges.
+        α = acos((τ.tangents ⋅ σ.tangents) / norm(τ.tangents) * norm(σ.tangents))
+        if α * (180 / π) > max_angle_deg
+            return BEAST.SauterSchwabQuadrature1D.CommonVertex(qd.marokhlinwandura[1],
+                qd.gausslegendre[1])
+        else
+            return BEAST.TellesQuadrature.TellesRule2D(qd.telles[2],
+                qd.telles[1])
+        end
+    elseif hits == 2        #Common Edge case
+        return BEAST.SauterSchwabQuadrature1D.CommonEdge(qd.marokhlinwandura[2],
+            qd.gausslegendre[2])
+    else                    #Near Singular case
+        #in testing for parallel edges, it was found that Telles starts to yield a benefit
+        #once there is a distance of about <= 0.5 * edge length between the edges. We
+        #use a circle centered around the midpoint of the test edge with a radius of
+        #0.5 * edge length to check if the trial edge is close enough to the test edge
+        #to justify the use of Telles.
+        test_midpoint = cartesian(neighborhood(τ, 0.5))
+        nullpoint = cartesian(neighborhood(σ, 0.0))
+        onepoint = cartesian(neighborhood(σ, 1.0))
+        t0 = test_midpoint - onepoint
+        t1 = test_midpoint - nullpoint
+        #if any of the endpoints of the trial edge is within the circle, we use Telles.
+        if norm(t0) / τ.volume <= 0.5 || norm(t1) / τ.volume <= 0.5
+            return BEAST.TellesQuadrature.TellesRule2D(qd.telles[2], qd.telles[1])
+        else
+            t2 = cartesian(neighborhood(σ, 1.0)) - nullpoint
+            #there exists a point closer to the test edge than the endpoints of the trial
+            #edge iff the dot product changes sign when multiplying the seperation vectors
+            #with one and the same tangent due to the nature of the cos: a⋅b = |a||b|cos(ϕ)
+            if (t0 ⋅ t2) * (t1 ⋅ t2) < 0
+                ϕ = acos(dot(t1, t2) / (norm(t1) * norm(t2)))
+                #if the relative distance is sufficiently small we use Telles
+                if norm(t1) * sin(ϕ) / τ.volume <= 0.5
+                    return BEAST.TellesQuadrature.TellesRule2D(qd.telles[2],
+                        qd.telles[1])
+                end
+            end
+        end
+    end
+
+    return DoubleQuadRule(  #Common case --> Gauss
+        qd.tpoints[1, i],
+        qd.bpoints[1, j],
     )
 end

--- a/src/postproc.jl
+++ b/src/postproc.jl
@@ -7,94 +7,94 @@ Compute the value of the function with the given collection of coeffient in the 
 """
 function facecurrents(coeffs, basis)
 
-	T = eltype(coeffs)
-	RT = real(T)
+    T = eltype(coeffs)
+    RT = real(T)
 
-	mesh = geometry(basis)
-	dom = domain(chart(mesh, first(mesh)))
+    mesh = geometry(basis)
+    dom = domain(chart(mesh, first(mesh)))
 
-	refs = refspace(basis)
-	numrefs = numfunctions(refs, dom)
+    refs = refspace(basis)
+    numrefs = numfunctions(refs, dom)
 
-	cells, tad, a2g = assemblydata(basis)
+    cells, tad, a2g = assemblydata(basis)
 
-	D = dimension(mesh)
-	# U = D+1
-	U = 3
+    D = dimension(mesh)
+    # U = D+1
+    U = 3
 
-	# TODO: remove ugliness
-	vals = refs(center(first(cells)))
-	PT = typeof(first(coeffs)*vals[1][1])
+    # TODO: remove ugliness
+    vals = refs(center(first(cells)))
+    PT = typeof(first(coeffs) * vals[1][1])
 
-	fcr = zeros(PT, numcells(mesh))
+    fcr = zeros(PT, numcells(mesh))
 
-	for (t,cell) in enumerate(cells)
+    for (t, cell) in enumerate(cells)
 
-		mps = neighborhood(cell, ones(RT,D)/(D+1))
+        mps = neighborhood(cell, ones(RT, D) / (D + 1))
         vals = refs(mps)
 
-		# assemble in the right hand side vector
-		for i in 1 : numrefs
-			fx = vals[i][1]
-            for (m,a) in tad[t,i]
-				# fcr[t] += coeffs[m] * a * fx
-				fcr[a2g[t]] += coeffs[m] * a * fx
-			end
-		end
-	end
+        # assemble in the right hand side vector
+        for i in 1:numrefs
+            fx = vals[i][1]
+            for (m, a) in tad[t, i]
+                # fcr[t] += coeffs[m] * a * fx
+                fcr[a2g[t]] += coeffs[m] * a * fx
+            end
+        end
+    end
 
-	return fcr, geometry(basis)
+    return fcr, geometry(basis)
 end
 
 function facecurrents(coeffs, basis::SpaceTimeBasis)
 
-	space_basis = basis.space
-	time_basis = basis.time
+    space_basis = basis.space
+    time_basis = basis.time
 
-	Nt = numfunctions(time_basis)
-	Δt = timestep(time_basis)
+    Nt = numfunctions(time_basis)
+    Δt = timestep(time_basis)
 
-	refs = refspace(space_basis)
-	trefs = refspace(time_basis)
-	numrefs = numfunctions(refs)
-	tnumrefs = numfunctions(trefs)
+    refs = refspace(space_basis)
+    trefs = refspace(time_basis)
+    numrefs = numfunctions(refs)
+    tnumrefs = numfunctions(trefs)
 
-	cells, ad = assemblydata(space_basis)
-	tcells, tad = assemblydata(time_basis)
+    cells, ad = assemblydata(space_basis)
+    tcells, tad = assemblydata(time_basis)
 
-	mesh = geometry(space_basis)
-	T = eltype(coeffs)
-	D = dimension(mesh)
-	U = D+1
+    mesh = geometry(space_basis)
+    T = eltype(coeffs)
+    D = dimension(mesh)
+    U = D + 1
 
-	# TODO: express relative to input types
-	PT = SVector{U, T}
-	fcr = zeros(PT, numcells(mesh), Nt)
+    # TODO: express relative to input types
+    PT = SVector{U,T}
+    fcr = zeros(PT, numcells(mesh), Nt)
 
-	for (k,tcell) in enumerate(tcells)
-		tmps = neighborhood(tcell,1)
-		tvals = trefs(tmps)
-		for (p,cell) in enumerate(cells)
-			mps = center(cell)
-	        vals = refs(mps)
+    for (k, tcell) in enumerate(tcells)
+        tmps = neighborhood(tcell, 1)
+        tvals = trefs(tmps)
+        for (p, cell) in enumerate(cells)
+            mps = center(cell)
+            vals = refs(mps)
 
-			# assemble
-			for i in 1:numrefs
-				fx = vals[i][1]
-				for j in 1:tnumrefs
-					tfx = tvals[j]
-	    			for (m,a) in ad[p,i]
-						for (n,b) in tad[k,j]
-							fcr[p,k] += (coeffs[m,n] * tfx * b) * a * fx
-						end
-					end
-				end
-			end
+            # assemble
+            for i in 1:numrefs
+                fx = vals[i][1]
+                for j in 1:tnumrefs
+                    tfx = tvals[j]
+                    for (m, a) in ad[p, i]
+                        for (n, b) in tad[k, j]
+                            fcr[p, k] += (coeffs[m, n] * tfx * b) * a * fx
+                        end
+                    end
+                end
+            end
 
-		end
-	end
+        end
+    end
 
-	return fcr, geometry(space_basis)
+    return fcr, geometry(space_basis)
 end
 
 function facecurrents(u, X1, Xs...)
@@ -129,6 +129,9 @@ function facecurrents(u, X::DirectProductSpace)
 	fcr, m
 end
 
+struct SingleNumQRule{A}
+    qps::A
+end
 
 """
 	potential(op, points, coeffs, basis)
@@ -270,7 +273,26 @@ function potential!(store, op, points, basis::SpaceTimeBasis)
 
 end
 
-function farfieldlocal!(zlocal,op,refspace,y,el,qr)
+
+function farfieldlocal!(zlocal, op, refspace, y, el, qr::SingleNumQRule)
+
+    for q in qr.qps
+        x = q.point
+        F = q.value
+        dx = q.weight
+
+        krn = kernelvals(op, y, x)
+        for r in 1:length(zlocal)
+            i = integrand(op, krn, y, F[r], x)
+            i *= dx
+            zlocal[r] += i
+        end
+
+    end
+
+end
+
+function farfieldlocal!(zlocal, op, refspace, y, el, qr)
 
     for q in qr
         x = q.point
@@ -287,11 +309,29 @@ function farfieldlocal!(zlocal,op,refspace,y,el,qr)
 
 end
 
-function farfieldlocal!(zlocal,op,trialrefs, timerefs,
-        p, testel, q, trialel, k, timeel, tb,quadrule)
+function farfieldlocal!(zlocal, op, refspace, y, el, qr::TellesQuadrature.TellesRule1D)
+    igd = (trial_chart=el,)
+    for q in qr.qps
+        q = TellesQuadrature.tellespoints(
+            igd, refspace, y, q)
+        x = q.point
+        F = q.value
+        dx = q.weight
+        krn = kernelvals(op, y, x)
+        for r in 1:length(zlocal)
+            i = integrand(op, krn, y, F[r], x)
+            i *= dx
+            zlocal[r] += i
+        end
 
-	M,N = size(zlocal)
-	Δt = tb.timestep
+    end
+end
+
+function farfieldlocal!(zlocal, op, trialrefs, timerefs,
+    p, testel, q, trialel, k, timeel, tb, quadrule)
+
+    M, N = size(zlocal)
+    Δt = tb.timestep
 
     for qr in quadrule[1]
         x = qr.point

--- a/src/quadrature/tellesints.jl
+++ b/src/quadrature/tellesints.jl
@@ -1,0 +1,39 @@
+struct DoubleNumSauterTellesQstrat{R,T,S} <: AbstractQuadStrat
+    outer_rule::R
+    inner_rule::R
+    telles_outer_rule::T
+    telles_inner_rule::T
+    sauter_schwab_common_edge::S
+    sauter_schwab_common_vert::S
+end
+
+struct SingleNumTellesQStrat{R,T} <: AbstractQuadStrat
+    gauss_rule::R
+    telles_rule::T
+end
+
+"""
+extending the momintegrals! function for the Telles quadrature strategy. This is used for
+near-singular integrals in 2D, where the singularity is not on the edge but close to it.
+"""
+
+function momintegrals!(op::Operator,
+    test_local_space, trial_local_space,
+    test_chart, trial_chart,
+    out, rule::BEAST.TellesQuadrature.TellesRule2D)
+
+    num_tshapes = numfunctions(test_local_space, domain(test_chart))
+    num_bshapes = numfunctions(trial_local_space, domain(trial_chart))
+
+    igd = Integrand(op, test_local_space, trial_local_space, test_chart, trial_chart)
+
+    G = BEAST.TellesQuadrature.telles_parametrized(igd, rule, num_tshapes, num_bshapes)
+
+    for j in 1:num_bshapes
+        for i in 1:num_tshapes
+            out[i, j] += G[i, j]
+        end
+    end
+
+    nothing
+end

--- a/src/quadrature/tellesquadrature.jl
+++ b/src/quadrature/tellesquadrature.jl
@@ -1,0 +1,362 @@
+module TellesQuadrature
+
+# -------- exportet parts
+# types
+export TellesRule2D
+export TellesRule1D
+# functions
+export telles_parametrized
+export tellespoints
+# -------- included files
+
+# -------- imports
+import ..scalartype
+
+# -------- used packages
+using FastGaussQuadrature
+using CompScienceMeshes
+using LinearAlgebra
+using StaticArrays
+using BEAST
+
+
+struct TellesRule2D{A}
+    qpso::A # GL quadrature for the outer integral
+    qpsi::A # GL quadrature for the inner integral
+end
+
+struct TellesRule1D{A}
+    qps::A # GL quadrature for the integral
+end
+
+# These are the values found to be working best for a static or Helmholtz kernel. They are
+# based on on the the procedure described in "Third degree polynomial transformation for
+#boundary element integrals: Further improvements" by Telles, 2002, and the values in Table
+#1 of that paper.
+const R_BAR_THRESHOLDS = [0.001, 0.005, 0.01, 0.03, 0.075, 0.15, 0.25, 0.4, 0.6, 0.8, 1.25,
+    2.0, 3.0, 4.0, 4.5]
+const R_BAR_VALUES = [0.051, 0.086, 0.116, 0.197, 0.316, 0.446, 0.564, 0.605, 0.731, 0.806,
+    0.892, 0.946, 0.972, 0.98, 0.99]
+
+"""
+The parameter r_bar is a function of the distance D from the reference point to the edge
+relative to the length of said edge. It is used in the quasi-singular case of the
+Tellestransformation. This function returns the r_bar value for a given D, based on the
+thresholds and values defined in R_BAR_THRESHOLDS and R_BAR_VALUES. It performs linear
+interpolation between the thresholds to find the appropriate r_bar value for any D within
+the range of the thresholds. Do note that these are somewhat kernel specific and while
+always lying between 0 (the transformation equals the singular case) and 1 (Gauss case with
+overhead), they are not necessarily optimal for all kernels.
+"""
+
+function getr_bar(D::Float64)
+    if D <= R_BAR_THRESHOLDS[1]
+        return R_BAR_VALUES[1]
+    elseif D >= R_BAR_THRESHOLDS[end]
+        return R_BAR_VALUES[end]
+    end
+
+    idx = searchsortedfirst(R_BAR_THRESHOLDS, D)
+
+    # Linear interpolation between idx-1 and idx
+    D0 = R_BAR_THRESHOLDS[idx-1]
+    D1 = R_BAR_THRESHOLDS[idx]
+    R0 = R_BAR_VALUES[idx-1]
+    R1 = R_BAR_VALUES[idx]
+
+    return R0 + (D - D0) * (R1 - R0) / (D1 - D0)
+end
+
+"""
+telles_deg3(acc, igd, aux, refpoint, qpsN1)
+
+This is the core function for the Telles transformation. It computes the integral of the
+given auxiliary function aux, which is a function of the transformed variable ξ, over the
+reference point refpoint, using the Telles transformation for a 1D edge. The function takes
+into account the geometry of the edge and the position of the reference point to determine
+whether the singularity is on the axis or not, and applies the appropriate transformation
+accordingly. The function uses the quadrature points and weights provided in qpsN1 to
+perform the numerical integration after the transformation. Further information on the
+transformation can be found in "Third degree polynomial transformation for boundary element
+integrals: Further improvements" by Telles, 2002.
+"""
+
+@inline function telles_deg3(acc, igd, aux, refpoint::SVector, qpsN1)
+
+    # --- TYPE OF ACCUMULATOR ---
+    #Telles prefers the Gauss points on the interval [-1,1]
+    #rather than [0,1] so we need to adapt our points and weights and keep the jacobian
+    jac = 1 / 2
+    qpsN = BEAST._legendre(length(qpsN1), -1, 1)
+    #[(2 * v1 - 1, 2 * w1) for (v1, w1) in qpsN1]
+    # --- GEOMETRY --- We find the point T on the edge where the tangent is perpendicular to
+    #the vector from the reference point to the edge. We then find the distance from the
+    #reference point to T, and use this to determine the parameter η_bar, which indicates
+    #how close the singularity is to the edge. We also compute the relative distance D,
+    #which is the distance from the reference point to T relative to the length of the edge,
+    #and use this to determine if we are in the quasi-singular case or not.
+    L = volume(igd.trial_chart)
+    η_tilde = normalize(igd.trial_chart.tangents[1])
+    nullpoint = cartesian(neighborhood(igd.trial_chart, 0.0))
+    onepoint = cartesian(neighborhood(igd.trial_chart, 1.0))
+
+    𝒹_tilde = refpoint - nullpoint
+    u_star = dot(η_tilde, 𝒹_tilde) / L
+    T = nullpoint + η_tilde * L * u_star
+    Dist = norm(refpoint - T)
+    η_bar = u_star * 2 - 1
+
+    if η_bar > 1
+        D = 2 * norm(refpoint - onepoint) / L
+    elseif η_bar < -1
+        D = 2 * norm(refpoint - nullpoint) / L
+    else
+        D = 2 * Dist / L
+    end
+
+    # --- AXIS CHECK ---
+    isonaxis = true
+    threshhold = 10^-13
+    if Dist > threshhold
+        isonaxis = false
+    end
+    #In the paper cited above, a splitting of the edge is proposed for the case where the
+    #singularity is close to the edge but not on the axis. However, it turns out that theh
+    #gain in accuracy is not worth the additional overhead it creates. This decision is
+    #based on empirical evidence testing against other methods of integrating in the quasi
+    #singular case with the same amount of quadrature points. This may be revisited in the
+    #future if further testing suggests that splitting could be beneficial in certain cases.
+    #=
+    if abs(η_bar) < 1
+        # Recursively split the edge, return type T
+        return tellesnocm_integratedeg3(K,
+            SVector(nullpoint, nullpoint + u_star * L * η_tilde),
+            refpoint, N
+        ) + tellesnocm_integratedeg3(K,
+            SVector(nullpoint + u_star* L * η_tilde, Edge[1]),
+            refpoint, N
+        )
+    end=#
+    # ==============================================================
+    # ======================= NOT ON AXIS ===========================
+    # ==============================================================
+    if !isonaxis
+        #We fetch r_bar with the function defined above, which is based on the distance D
+        #from the reference point to the edge relative to the length of the edge. This
+        #parameter is crucial for determining the coefficients of the cubic transformation
+        #used in the Telles method for quasi-singular integrals.
+        r_bar = getr_bar(D)
+
+        q = (η_bar * (3 - 2 * r_bar) - (2 * η_bar^3) / (1 + 2 * r_bar)) /
+            (2 * (1 + 2 * r_bar)^2) - η_bar / (2 * (1 + 2 * r_bar))
+        p = (4 * r_bar * (1 - r_bar) + 3 * (1 - η_bar^2)) /
+            (3 * (1 + 2 * r_bar)^2)
+
+        γ_bar = cbrt(-q + sqrt(q^2 + p^3)) +
+                cbrt(-q - sqrt(q^2 + p^3)) +
+                η_bar / (1 + 2 * r_bar)
+
+        Q = 1 + 3 * γ_bar^2
+
+        # Polynomial coefficients
+        coef = (
+            a=(1 - r_bar) / Q,
+            b=-3 * (1 - r_bar) * γ_bar / Q,
+            c=(r_bar + 3 * γ_bar^2) / Q,
+            d=3 * (1 - r_bar) * γ_bar / Q    # (=-b)
+        )
+
+        # A let-block keeps mapv / dmapv visible for loop use
+        let a = coef.a, b = coef.b, c = coef.c, d = coef.d
+
+            @inline mapv(v1) = a * v1^3 + b * v1^2 + c * v1 + d
+            @inline dmapv(v1) = 3 * a * v1^2 + 2 * b * v1 + c
+
+            @inbounds for j in eachindex(qpsN)
+                v1, w1 = qpsN[j]
+
+                t = mapv(v1)
+                ξ = (t + 1) / 2
+                #x = P1 + ξ * Δ
+
+                acc += jac * dmapv(v1) * w1 *
+                       aux(ξ)
+            end
+        end
+
+        return acc
+    end
+
+    # ==============================================================
+    # ========================== ON AXIS ===========================
+    # ==============================================================
+
+    # the axis that is refered to here is the axis of the edge, so the singularity is on the
+    # axis if the reference point is directly above or below the edge. In this case, we use
+    # a different transformation, which is based on a cubic polynomial with coefficients
+    # determined by η_bar, which is the parameter in [-1,1]
+
+    η_star = η_bar^2 - 1
+
+    γ_bar = cbrt(η_bar * η_star + abs(η_star)) +
+            cbrt(η_bar * η_star - abs(η_star)) +
+            η_bar
+
+    denom = 1 + 3 * γ_bar^2
+
+    let γ = γ_bar, denom = denom
+
+        @inline mapv(v1) = ((v1 - γ)^3 + γ * (γ^2 + 3)) / denom
+        @inline dmapv(v1) = 3 * (v1 - γ)^2 / denom
+
+        @inbounds for j in eachindex(qpsN)
+            v1, w1 = qpsN[j]
+
+            t = mapv(v1)
+            ξ = (t + 1) / 2
+
+            #x = P1 + ξ * Δ
+
+            acc += jac * dmapv(v1) * w1 *
+                   aux(ξ)
+        end
+    end
+
+    return acc
+end
+
+function telles_parametrized(igd, rule::TellesRule2D, num_tshapes, num_bshapes)
+    qpsi = rule.qpsi
+    qpso = rule.qpso
+    G = zeros(scalartype(igd.operator), num_tshapes, num_bshapes)
+    for (v1, w1) in qpso
+        G += w1 * telles_deg3(zeros(scalartype(igd.operator), num_tshapes, num_bshapes),
+            igd, x -> igd(x, v1), cartesian(igd.test_chart, v1), qpsi)
+    end
+    return G
+end
+
+"""
+tellespoints(igd, refspace, refpoint, qpair)
+
+For the postprocessing of near-singular integrals, we need to evaluate the integrand at the
+quadrature points of the Telles transformation. This function takes in the integration
+geometry data (igd), the reference space, the reference point, and a quadrature pair (qpair)
+consisting of a quadrature point and weight. It applies the Telles transformation to compute
+the corresponding point in the configuration space and its associated weight, which can then
+be used for evaluating the integrand at that point. The function handles both cases where
+the referencepoint is on a common axis with the trial element and where it is not, ensuring
+accurate evaluation of near-singular integrals.
+"""
+@inline function tellespoints(igd, refspace, refpoint, qpair)
+    v1, w1 = qpair
+    jac = 1 / 2
+    # --- GEOMETRY --- We find the point T on the edge where the tangent is perpendicular to
+    #the vector from the reference point to the edge. We then find the distance from the
+    #reference point to T, and use this to determine the parameter η_bar, which indicates
+    #how close the singularity is to the edge. We also compute the relative distance D,
+    #which is the distance from the reference point to T relative to the length of the edge,
+    #and use this to determine if we are in the quasi-singular case or not.
+    L = volume(igd.trial_chart)
+    η_tilde = normalize(igd.trial_chart.tangents[1])
+    nullpoint = cartesian(neighborhood(igd.trial_chart, 0.0))
+    onepoint = cartesian(neighborhood(igd.trial_chart, 1.0))
+
+    𝒹_tilde = refpoint - nullpoint
+    u_star = dot(η_tilde, 𝒹_tilde) / L
+    T = nullpoint + η_tilde * L * u_star
+    Dist = norm(refpoint - T)
+    η_bar = u_star * 2 - 1
+
+    if η_bar > 1
+        D = 2 * norm(refpoint - onepoint) / L
+    elseif η_bar < -1
+        D = 2 * norm(refpoint - nullpoint) / L
+    else
+        D = 2 * Dist / L
+    end
+
+    # --- AXIS CHECK ---
+    isonaxis = true
+    threshhold = 10^-13
+    if Dist > threshhold
+        isonaxis = false
+    end
+    # ==============================================================
+    # ======================= NOT ON AXIS ===========================
+    # ==============================================================
+    if !isonaxis
+        #We fetch r_bar with the function defined above, which is based on the distance D
+        #from the reference point to the edge relative to the length of the edge. This
+        #parameter is crucial for determining the coefficients of the cubic transformation
+        #used in the Telles method for quasi-singular integrals.
+        r_bar = getr_bar(D)
+
+        q = (η_bar * (3 - 2 * r_bar) - (2 * η_bar^3) / (1 + 2 * r_bar)) /
+            (2 * (1 + 2 * r_bar)^2) - η_bar / (2 * (1 + 2 * r_bar))
+        p = (4 * r_bar * (1 - r_bar) + 3 * (1 - η_bar^2)) /
+            (3 * (1 + 2 * r_bar)^2)
+
+        γ_bar = cbrt(-q + sqrt(q^2 + p^3)) +
+                cbrt(-q - sqrt(q^2 + p^3)) +
+                η_bar / (1 + 2 * r_bar)
+
+        Q = 1 + 3 * γ_bar^2
+
+        # Polynomial coefficients
+        coef = (
+            a=(1 - r_bar) / Q,
+            b=-3 * (1 - r_bar) * γ_bar / Q,
+            c=(r_bar + 3 * γ_bar^2) / Q,
+            d=3 * (1 - r_bar) * γ_bar / Q    # (=-b)
+        )
+
+        # A let-block keeps mapv / dmapv visible for loop use
+        acc = let a = coef.a, b = coef.b, c = coef.c, d = coef.d
+
+            @inline mapv(v1) = a * v1^3 + b * v1^2 + c * v1 + d
+            @inline dmapv(v1) = 3 * a * v1^2 + 2 * b * v1 + c
+
+            t = mapv(v1)
+            ξ = (t + 1) / 2
+            mp = neighborhood(igd.trial_chart, ξ)
+            (weight=jac * dmapv(v1) * w1 * jacobian(mp), point=mp, value=refspace(mp))
+        end
+
+        return acc
+    end
+    # ==============================================================
+    # ========================== ON AXIS ===========================
+    # ==============================================================
+
+    # the axis that is refered to here is the axis of the edge, so the singularity is on the
+    # axis if the reference point is directly above or below the edge. In this case, we use
+    # a different transformation, which is based on a cubic polynomial with coefficients
+    # determined by η_bar, which is the parameter in [-1,1]
+
+    η_star = η_bar^2 - 1
+
+    γ_bar = cbrt(η_bar * η_star + abs(η_star)) +
+            cbrt(η_bar * η_star - abs(η_star)) +
+            η_bar
+
+    denom = 1 + 3 * γ_bar^2
+
+    acc = let γ = γ_bar, denom = denom
+
+        @inline mapv(v1) = ((v1 - γ)^3 + γ * (γ^2 + 3)) / denom
+        @inline dmapv(v1) = 3 * (v1 - γ)^2 / denom
+
+        t = mapv(v1)
+        ξ = (t + 1) / 2
+
+        #x = P1 + ξ * Δ
+
+        mp = neighborhood(igd.trial_chart, ξ)
+        (weight=jac * dmapv(v1) * w1 * jacobian(mp), point=mp, value=refspace(mp))
+    end
+
+    return acc
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,7 @@ include("test_assemble_refinements.jl")
 include("test_dipole.jl")
 
 include("test_sauterschwabints1D.jl")
+include("test_telles.jl")
 include("test_hh2d_exec.jl")
 include("test_hh2d_ops.jl")
 include("test_hh2d_mie.jl")

--- a/test/test_telles.jl
+++ b/test/test_telles.jl
@@ -1,0 +1,189 @@
+using BEAST
+using CompScienceMeshes
+using StaticArrays
+using LinearAlgebra
+using Test
+#import PlotlyJS       <-- For Plottong only
+
+
+@testset "Telles-Integration" begin
+    ℒ = 10.0
+    𝒹 = 2.5 * ℒ / 2
+    Stat = Helmholtz2D.singlelayer()
+    P1 = SVector(0.0, 0.0)
+    P2 = SVector(ℒ, 0.0)
+    P3 = SVector(P1[1] + 0.25 * ℒ, P1[2] + 𝒹)
+    P4 = SVector(P2[1] + 0.25 * ℒ, P2[2] + 𝒹)
+    vertices = [P1, P2, P3, P4]
+
+    el1 = CompScienceMeshes.SimplexGraph{2}(index(1,2))
+    el2 = CompScienceMeshes.SimplexGraph{2}(index(3,4))
+    faces = [el1, el2]
+    tstmesh = Mesh(vertices, faces)
+    X01 = lagrangecxd0(tstmesh)
+    function referencestat(l::Float64, y::SVector)
+        return -(1 / (4 * π)) * (((1 * l - y[1]) * log((1 * l - y[1])^2 + y[2]^2) - 2 * (1 * l - y[1]) + 2 * y[2] * atan((1 * l - y[1]) / y[2])) - ((0 * l - y[1]) * log((0 * l - y[1])^2 + y[2]^2) - 2 * (0 * l - y[1]) + 2 * y[2] * atan((0 * l - y[1]) / y[2])))
+    end
+    function referencestatE(Edge::SVector{2,<:SVector}, Edge2::SVector{2,<:SVector}, N::Int)
+        qpsN = BEAST._legendre(N, -1.0, 1.0)
+        J = (norm(Edge2[2] - Edge2[1]) / 2)
+        Δx = (Edge2[2][1] - Edge2[1][1])
+        Δy = (Edge2[2][2] - Edge2[1][2])
+        L = norm(Edge[2] - Edge[1])
+        return sum(w1 * J * referencestat(L, SVector(Edge2[1][1] + ((v1 + 1) / 2) * Δx, Edge2[1][2] + ((v1 + 1) / 2) * Δy)) for (v1, w1) in qpsN)
+    end
+    reforder = 10000
+    relerT = Float64[]
+    ref = referencestatE(SVector(P1, P2), SVector(P3, P4), reforder)
+    quads = [10, 30]
+    for i in quads
+        quadstrat = BEAST.DoubleNumSauterTellesQstrat(i, i, i, i, i, i)
+        tel = assemble(Stat, X01, X01, quadstrat=quadstrat)[1, 2]
+        push!(relerT, abs(tel - ref) / abs(ref))
+    end
+
+
+    @test relerT[1] < 10^-3
+    @test relerT[2] < 10^-7
+
+    function returntestmesh(𝒹::Float64, α::Float64, ℒ::Float64)
+        α = α * π / 180
+        P1 = SVector(-ℒ / 2, 0.0)
+        P6 = SVector(ℒ / 2, 0.0)
+        P3 = SVector(P1[1], P1[2] + 𝒹)
+        P4 = SVector(P6[1], P6[2] + 𝒹)
+        P2 = SVector(P1[1] - (𝒹 * 0.5 / tan(α / 2)), P1[2] + 𝒹 / 2)
+        P5 = SVector(P6[1] + (𝒹 * 0.5 / tan(α / 2)), P6[2] + 𝒹 / 2)
+        vertices = [P1, P2, P3, P4, P5, P6]
+        el1 = CompScienceMeshes.SimplexGraph{2}(index(1,2))
+        el2 = CompScienceMeshes.SimplexGraph{2}(index(2,3))
+        el3 = CompScienceMeshes.SimplexGraph{2}(index(3,4))
+        el4 = CompScienceMeshes.SimplexGraph{2}(index(4,5))
+        el5 = CompScienceMeshes.SimplexGraph{2}(index(5,6))
+        el6 = CompScienceMeshes.SimplexGraph{2}(index(6,1))
+        faces = [el1, el2, el3, el4, el5, el6]
+        M = Mesh(vertices, faces)
+        return M
+    end
+    mesh = returntestmesh(1 / 20, 10.0, 1.0)
+    #=========================For Plotting only=========================##=
+    function make_3d(M)
+        v = M.vertices
+        f = M.faces
+        new = [SVector(v1[1], v1[2], 0.0) for v1 in v]
+        M3d = Mesh(new, f)
+        return M3d
+    end
+    mesh3d = make_3d(mesh)
+    plt = PlotlyJS.plot(CompScienceMeshes.wireframe(mesh3d))
+    PlotlyJS.relayout!(plt, scene=PlotlyJS.attr(
+    aspectmode="data"   # keeps x, y, z scaling equal to data units
+    ))
+    PlotlyJS.display(plt)
+    =##============================End Plots==============================#
+    X1 = lagrangec0d1(mesh)
+    quads = [10, 30]
+    relD = Float64[]
+    for i in quads
+        quadstrat = BEAST.DoubleNumSauterTellesQstrat(i, i, i, i, i, i)
+        default = BEAST.DoubleNumSauterQstrat(i, i, 0, 4, i, i)
+        B1 = assemble(Stat, X1, X1, quadstrat=quadstrat)
+        B2 = assemble(Stat, X1, X1, quadstrat=default)
+        push!(relD, norm(B2 - B1) / norm(B2))
+    end
+    @test relD[1] < 10^-2
+    @test relD[2] < 10^-4
+end
+
+@testset "Telles-Integration: Helmholtz2D Nearfield" begin
+
+k = 0.0
+r = 10.0
+circle = CompScienceMeshes.meshcircle(r, 1.0)
+
+X0 = lagrangecxd0(circle)
+X1 = lagrangec0d1(circle)
+
+S = Helmholtz2D.singlelayer(;)
+D = Helmholtz2D.doublelayer(;)
+Dt = Helmholtz2D.doublelayer_transposed(;)
+N = Helmholtz2D.hypersingular(;)
+
+
+q = 100.0
+ϵ = 1.0
+
+# Interior problem
+# Formulations from Sauter and Schwab, Boundary Element Methods(2011), Chapter 3.4.1.1
+
+pos1 = SVector(r * 1.5, 0.0)  # positioning of point charges
+pos2 = SVector(-r * 1.5, 0.0)
+
+charge1 = Helmholtz2D.monopole(position=pos1, amplitude=q / (4 * π * ϵ))
+charge2 = Helmholtz2D.monopole(position=pos2, amplitude=-q / (4 * π * ϵ))
+
+# Potential of point charges
+Φ_inc(x) = charge1(x) + charge2(x)
+
+gD0 = assemble(DirichletTrace(charge1), X0) + assemble(DirichletTrace(charge2), X0)
+gD1 = assemble(DirichletTrace(charge1), X1) + assemble(DirichletTrace(charge2), X1)
+gN = assemble(∂n(charge1), X1) + assemble(BEAST.n ⋅ grad(charge2), X1)
+
+G = assemble(Identity(), X1, X1)
+o = ones(numfunctions(X1))
+
+# Interior Dirichlet problem - compare Sauter & Schwab eqs. 3.81
+M_IDPSL = assemble(S, X0, X0) # Single layer (SL)
+M_IDPDL = (-1 / 2 * G + assemble(D, X1, X1)) # Double layer (DL)
+
+# Interior Neumann problem
+# Neumann derivative from DL potential with deflected nullspace
+M_INPDL = assemble(N, X1, X1) + G * o * o' * G
+# Neumann derivative from SL potential with deflected nullspace
+M_INPSL = (1 / 2 * G + assemble(Dt, X1, X1)) + G * o * o' * G
+
+ρ_IDPSL = M_IDPSL \ (-gD0)
+ρ_IDPDL = M_IDPDL \ (-gD1)
+
+ρ_INPSL = M_INPSL \ (-gN)
+ρ_INPDL = M_INPDL \ (gN)
+
+#In order to test the Telles quadrature, we evaluate the potentials at points close to the
+#boundary, where the integrals are nearly singular. We expect the Telles quadrature to
+#perform better than standard Gaussian quadrature in this regime.
+
+pts = []
+currentvert = circle.vertices[1]
+for i in eachindex(circle.vertices[2:end])
+    tan = circle.vertices[i+1] - currentvert
+    midpoint = (currentvert + (tan ./ 2))
+    push!(pts, midpoint .* 0.99) # push the midpoint of each edge to the interior and add to pts
+    currentvert = circle.vertices[i]
+end
+
+pot_IDPSL = potential(HH2DSingleLayerNear(S), pts, ρ_IDPSL, X0; type=ComplexF64, quadstrat=BEAST.SingleNumQStrat(3))
+pot_IDPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_IDPDL, X1; type=ComplexF64, quadstrat=BEAST.SingleNumQStrat(3))
+pot_INPSL = potential(HH2DSingleLayerNear(S), pts, ρ_INPSL, X1; type=ComplexF64, quadstrat=BEAST.SingleNumQStrat(3))
+pot_INPDL = potential(HH2DDoubleLayerNear(D), pts, ρ_INPDL, X1; type=ComplexF64, quadstrat=BEAST.SingleNumQStrat(3))
+
+pot_IDPSL_telles = potential(HH2DSingleLayerNear(S), pts, ρ_IDPSL, X0; type=ComplexF64, quadstrat=BEAST.SingleNumTellesQStrat(3, 3))
+pot_IDPDL_telles = potential(HH2DDoubleLayerNear(D), pts, ρ_IDPDL, X1; type=ComplexF64, quadstrat=BEAST.SingleNumTellesQStrat(3, 3))
+pot_INPSL_telles = potential(HH2DSingleLayerNear(S), pts, ρ_INPSL, X1; type=ComplexF64, quadstrat=BEAST.SingleNumTellesQStrat(3, 3))
+pot_INPDL_telles = potential(HH2DDoubleLayerNear(D), pts, ρ_INPDL, X1; type=ComplexF64, quadstrat=BEAST.SingleNumTellesQStrat(3, 3))
+
+# Total field inside should be zero
+err_IDPSL_pot = norm(pot_IDPSL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+err_IDPDL_pot = norm(pot_IDPDL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+err_INPSL_pot = norm(pot_INPSL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+err_INPDL_pot = norm(pot_INPDL + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+
+err_IDPSL_pot_telles = norm(pot_IDPSL_telles + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+err_IDPDL_pot_telles = norm(pot_IDPDL_telles + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+err_INPSL_pot_telles = norm(pot_INPSL_telles + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+err_INPDL_pot_telles = norm(pot_INPDL_telles + Φ_inc.(pts)) / norm(Φ_inc.(pts))
+
+@test err_IDPSL_pot > err_IDPSL_pot_telles
+@test err_IDPDL_pot > err_IDPDL_pot_telles
+@test err_INPSL_pot > err_INPSL_pot_telles
+@test err_INPDL_pot > err_INPDL_pot_telles
+end


### PR DESCRIPTION
Implementing a transformation in the case of integrating in 2D for edge-elements in the near singular case.
We apply a Telles transformation to the quadrature points moving them closer to the critical points. This enhances accuracy when comparing to Gaussian quadrature.